### PR TITLE
added coveralls and jacoco plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 after_success:
-  - mvn clean cobertura:cobertura coveralls:report
+  - mvn clean cobertura:cobertura-integration-test coveralls:report
 
 before_deploy: >
   sudo apt-get install python-pip &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 after_success:
-  - mvn clean cobertura:cobertura-integration-test coveralls:report
+  - mvn clean cobertura:cobertura coveralls:report
 
 before_deploy: >
   sudo apt-get install python-pip &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 after_success:
-  - mvn clean test jacoco:report coveralls:report
+  - mvn clean cobertura:cobertura coveralls:report
 
 before_deploy: >
   sudo apt-get install python-pip &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+after_success:
+  - mvn clean test jacoco:report coveralls:report
+
 before_deploy: >
   sudo apt-get install python-pip &&
   ant -f build/ant.xml

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ CloudSlang
 CloudSlang is a YAML based language for writing human-readable workflows for the CloudSlang Orchestration Engine (Score). This project includes the CLI to trigger flows.
 
 [![Build Status](https://travis-ci.org/CloudSlang/cloud-slang.svg?branch=master)](https://travis-ci.org/CloudSlang/cloud-slang)
+[![Coverage Status](https://coveralls.io/repos/CloudSlang/cloud-slang/badge.svg?branch=coveralls)](https://coveralls.io/r/CloudSlang/cloud-slang?branch=coveralls)
 
 #### Getting started:
 

--- a/pom.xml
+++ b/pom.xml
@@ -314,17 +314,15 @@
                     <version>3.1.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.2.201409121644</version>
-                    <executions>
-                        <execution>
-                            <id>prepare-agent</id>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                    </executions>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>cobertura-maven-plugin</artifactId>
+                    <version>2.7</version>
+                    <configuration>
+                        <format>xml</format>
+                        <maxmem>256m</maxmem>
+                        <!-- aggregated reports for multi-module projects -->
+                        <aggregate>true</aggregate>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,24 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.7.2.201409121644</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>2.4.0</version>


### PR DESCRIPTION
Using coveralls for monitoring our code coverage.
we can set rules in coveralls for failing for desegregation.
I would recommend we should merge it after we fix the problems it points to.
