### PR TITLE
Allow builder to run w\o default test suite

### DIFF
--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
@@ -38,8 +38,10 @@ public class SlangBuildMain {
 
     private static final String CONTENT_DIR =  File.separator + "content";
     private static final String TEST_DIR = File.separator + "test";
+    public static final String DEFAULT_TESTS = "default";
 
     private final static Logger log = Logger.getLogger(SlangBuildMain.class);
+    private static String NOT_TS = "!";
 
     public static void main(String[] args) {
         ApplicationArgs appArgs = new ApplicationArgs();
@@ -47,7 +49,7 @@ public class SlangBuildMain {
         String projectPath = parseProjectPathArg(appArgs);
         String contentPath = StringUtils.defaultIfEmpty(appArgs.getContentRoot(), projectPath + CONTENT_DIR);
         String testsPath = StringUtils.defaultIfEmpty(appArgs.getTestRoot(), projectPath + TEST_DIR);
-        List<String> testSuites = ListUtils.defaultIfNull(appArgs.getTestSuites(), new ArrayList<String>());
+        List<String> testSuites = parseTestSuites(appArgs);
 
         log.info("");
         log.info("------------------------------------------------------------");
@@ -89,6 +91,20 @@ public class SlangBuildMain {
             log.error("");
             System.exit(1);
         }
+    }
+
+    private static List<String> parseTestSuites(ApplicationArgs appArgs) {
+        boolean runDefaultTests = true;
+        List<String> testSuites = ListUtils.defaultIfNull(appArgs.getTestSuites(), new ArrayList<String>());
+        for(String testSuite : testSuites){
+            if(testSuite.equalsIgnoreCase(NOT_TS + DEFAULT_TESTS)){
+                runDefaultTests = false;
+            }
+        }
+        if(runDefaultTests && !testSuites.contains(DEFAULT_TESTS)){
+            testSuites.add(DEFAULT_TESTS);
+        }
+        return testSuites;
     }
 
     private static void printBuildSuccessSummary(String projectPath, SlangBuildResults buildResults, RunTestsResults runTestsResults, Map<String, TestRun> skippedTests) {

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
@@ -94,14 +94,17 @@ public class SlangBuildMain {
     }
 
     private static List<String> parseTestSuites(ApplicationArgs appArgs) {
+        List<String> testSuites = new ArrayList<>();
         boolean runDefaultTests = true;
-        List<String> testSuites = ListUtils.defaultIfNull(appArgs.getTestSuites(), new ArrayList<String>());
-        for(String testSuite : testSuites){
-            if(testSuite.equalsIgnoreCase(NOT_TS + DEFAULT_TESTS)){
+        List<String> testSuitesArg = ListUtils.defaultIfNull(appArgs.getTestSuites(), new ArrayList<String>());
+        for(String testSuite : testSuitesArg){
+            if(!testSuite.startsWith(NOT_TS)){
+                testSuites.add(testSuite);
+            } else if(testSuite.equalsIgnoreCase(NOT_TS + DEFAULT_TESTS)){
                 runDefaultTests = false;
             }
         }
-        if(runDefaultTests && !testSuites.contains(DEFAULT_TESTS)){
+        if(runDefaultTests && !testSuitesArg.contains(DEFAULT_TESTS)){
             testSuites.add(DEFAULT_TESTS);
         }
         return testSuites;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuilder.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuilder.java
@@ -98,7 +98,7 @@ public class SlangBuilder {
 
         log.info("");
         log.info("--- running tests ---");
-        log.info("Going to run " + testCases.size() + " tests");
+        log.info("Found " + testCases.size() + " tests");
         return slangTestRunner.runAllTests(projectPath, testCases, compiledFlows, testSuites);
     }
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
@@ -14,6 +14,7 @@ import io.cloudslang.lang.compiler.SlangSource;
 import io.cloudslang.lang.entities.CompilationArtifact;
 import io.cloudslang.lang.entities.ScoreLangConstants;
 import io.cloudslang.lang.runtime.env.ReturnValues;
+import io.cloudslang.lang.tools.build.SlangBuildMain;
 import io.cloudslang.lang.tools.build.tester.parse.SlangTestCase;
 import io.cloudslang.lang.tools.build.tester.parse.TestCasesYamlParser;
 import io.cloudslang.score.events.EventConstants;
@@ -112,7 +113,8 @@ public class SlangTestRunner {
                 runTestsResults.addFailedTest(UNAVAILABLE_NAME, new TestRun(testCase, "Test case cannot be null"));
                 continue;
             }
-            if (CollectionUtils.isEmpty(testCase.getTestSuites()) || CollectionUtils.containsAny(testSuites, testCase.getTestSuites())) {
+            if ((CollectionUtils.isEmpty(testCase.getTestSuites()) && testSuites.contains(SlangBuildMain.DEFAULT_TESTS)) ||
+                    CollectionUtils.containsAny(testSuites, testCase.getTestSuites())) {
                 log.info("Running test: " + testCaseEntry.getKey() + " - " + testCase.getDescription());
                 try {
                     CompilationArtifact compiledTestFlow = getCompiledTestFlow(compiledFlows, testCase);

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
@@ -62,6 +62,8 @@ public class SlangTestRunnerTest {
     public ExpectedException exception = ExpectedException.none();
 
     private List<String> specialTestSuite = Arrays.asList("special");
+    private List<String> specialRuntimeTestSuite = Arrays.asList("special","default");
+    private List<String> defaultTestSuite = Arrays.asList("default");
 
 
     @Before
@@ -161,7 +163,7 @@ public class SlangTestRunnerTest {
         Map<String, SlangTestCase> testCases = new HashMap<>();
         SlangTestCase testCase = new SlangTestCase("test1", null, null, null, null, null, null, null, null);
         testCases.put("test1", testCase);
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, new HashMap<String, CompilationArtifact>(), new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, new HashMap<String, CompilationArtifact>(), defaultTestSuite);
         Map<String, TestRun> failedTests = runTestsResults.getFailedTests();
         Assert.assertEquals("1 test case should fail", 1, failedTests.size());
         TestRun failedTest = failedTests.values().iterator().next();
@@ -175,7 +177,7 @@ public class SlangTestRunnerTest {
         Map<String, SlangTestCase> testCases = new HashMap<>();
         SlangTestCase testCase = new SlangTestCase("test1", "testFlowPath", null, null, null, null, null, null, null);
         testCases.put("test1", testCase);
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, new HashMap<String, CompilationArtifact>(), new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, new HashMap<String, CompilationArtifact>(), defaultTestSuite);
         Map<String, TestRun> failedTests = runTestsResults.getFailedTests();
         Assert.assertEquals("1 test case should fail", 1, failedTests.size());
         TestRun failedTest = failedTests.values().iterator().next();
@@ -192,7 +194,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("No test cases should fail", 0, runTestsResults.getFailedTests().size());
     }
 
@@ -204,7 +206,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows,defaultTestSuite);
         Assert.assertEquals("No test cases should fail", 0, runTestsResults.getFailedTests()
                                                                            .size());
     }
@@ -228,7 +230,7 @@ public class SlangTestRunnerTest {
         convertedOutputs.put("output1", "value1");
         convertedOutputs.put("output2", "value2");
         prepareMockForEventListenerWithSuccessResultAndOutputs(convertedOutputs);
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("No test cases should fail", 0, runTestsResults.getFailedTests().size());
     }
 
@@ -246,7 +248,7 @@ public class SlangTestRunnerTest {
         Map<String, Serializable> convertedOutputs = new HashMap<>();
         convertedOutputs.put("output1", null);
         prepareMockForEventListenerWithSuccessResultAndOutputs(convertedOutputs);
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("No test cases should fail", 0, runTestsResults.getFailedTests().size());
     }
 
@@ -264,7 +266,7 @@ public class SlangTestRunnerTest {
         Map<String, Serializable> convertedOutputs = new HashMap<>();
         convertedOutputs.put("output1", 1);
         prepareMockForEventListenerWithSuccessResultAndOutputs(convertedOutputs);
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("No test cases should fail", 0, runTestsResults.getFailedTests().size());
     }
 
@@ -282,7 +284,7 @@ public class SlangTestRunnerTest {
         Map<String, Serializable> convertedOutputs = new HashMap<>();
         convertedOutputs.put("output1", 2);
         prepareMockForEventListenerWithSuccessResultAndOutputs(convertedOutputs);
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("1 test cases should fail", 1, runTestsResults.getFailedTests().size());
     }
 
@@ -300,7 +302,7 @@ public class SlangTestRunnerTest {
         Map<String, Serializable> convertedOutputs = new HashMap<>();
         convertedOutputs.put("output1", Boolean.TRUE);
         prepareMockForEventListenerWithSuccessResultAndOutputs(convertedOutputs);
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("No test cases should fail", 0, runTestsResults.getFailedTests().size());
     }
 
@@ -312,7 +314,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSlangExceptionEvent();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("No test case should fail", 0, runTestsResults.getFailedTests().size());
     }
 
@@ -324,7 +326,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("1 test case should fail", 1, runTestsResults.getFailedTests().size());
     }
 
@@ -336,7 +338,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSlangExceptionEvent();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("1 test case should fail", 1, runTestsResults.getFailedTests().size());
     }
 
@@ -348,7 +350,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("No test case should fail", 0, runTestsResults.getFailedTests().size());
     }
 
@@ -360,7 +362,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("1 test case should fail", 1, runTestsResults.getFailedTests().size());
     }
 
@@ -372,7 +374,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("No test cases should fail", 0, runTestsResults.getFailedTests().size());
     }
 
@@ -384,7 +386,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, specialTestSuite);
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, specialRuntimeTestSuite);
         Assert.assertEquals("No test cases should be skipped", 0, runTestsResults.getSkippedTests().size());
     }
 
@@ -396,7 +398,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        List<String> runtimeTestSuites = new ArrayList<>(specialTestSuite);
+        List<String> runtimeTestSuites = new ArrayList<>(specialRuntimeTestSuite);
         runtimeTestSuites.add("anotherTestSuite");
         RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, runtimeTestSuites);
         Assert.assertEquals("No test cases should be skipped", 0, runTestsResults.getSkippedTests().size());
@@ -410,7 +412,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        List<String> runtimeTestSuites = new ArrayList<>(specialTestSuite);
+        List<String> runtimeTestSuites = new ArrayList<>(specialRuntimeTestSuite);
         runtimeTestSuites.add("anotherTestSuite");
         RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, runtimeTestSuites);
         Assert.assertEquals("No test cases should be skipped", 0, runTestsResults.getSkippedTests().size());
@@ -424,7 +426,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        List<String> runtimeTestSuites = new ArrayList<>(specialTestSuite);
+        List<String> runtimeTestSuites = new ArrayList<>(specialRuntimeTestSuite);
         runtimeTestSuites.add("anotherTestSuite");
         RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, runtimeTestSuites);
         Assert.assertEquals("1 test case should be skipped", 1, runTestsResults.getSkippedTests().size());
@@ -438,7 +440,7 @@ public class SlangTestRunnerTest {
         HashMap<String, CompilationArtifact> compiledFlows = new HashMap<>();
         compiledFlows.put("testFlowPath", new CompilationArtifact(new ExecutionPlan(), null, null, null));
         prepareMockForEventListenerWithSuccessResult();
-        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, new ArrayList<String>());
+        RunTestsResults runTestsResults = slangTestRunner.runAllTests("path", testCases, compiledFlows, defaultTestSuite);
         Assert.assertEquals("1 test case should be skipped", 1, runTestsResults.getSkippedTests().size());
     }
 


### PR DESCRIPTION
fixes #296
Allow running the builder without running the default test suite - by specifying testSuite: !default

Signed-off-by: Orit Stone <orit.stone@hp.com>