### PR TITLE
When no default value is specified, do not put the name of the input as it's expression 

### DIFF
--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInputsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInputsTransformer.java
@@ -68,7 +68,7 @@ public abstract class AbstractInputsTransformer {
                 (boolean) props.get(OVERRIDABLE_KEY);
         boolean defaultSpecified = props.containsKey(DEFAULT_KEY);
         String inputName = entry.getKey();
-        String expression = props.containsKey(DEFAULT_KEY) ? (String)props.get(DEFAULT_KEY).toString() : null;
+        String expression = defaultSpecified ? props.get(DEFAULT_KEY).toString() : null;
         String systemPropertyName = (String) props.get(SYSTEM_PROPERTY_KEY);
 
         if (!overridable && !defaultSpecified && StringUtils.isEmpty(systemPropertyName)) {

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInputsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInputsTransformer.java
@@ -68,8 +68,7 @@ public abstract class AbstractInputsTransformer {
                 (boolean) props.get(OVERRIDABLE_KEY);
         boolean defaultSpecified = props.containsKey(DEFAULT_KEY);
         String inputName = entry.getKey();
-        String expression = defaultSpecified ? props.get(DEFAULT_KEY)
-                                                    .toString() : inputName;
+        String expression = props.containsKey(DEFAULT_KEY) ? (String)props.get(DEFAULT_KEY).toString() : null;
         String systemPropertyName = (String) props.get(SYSTEM_PROPERTY_KEY);
 
         if (!overridable && !defaultSpecified && StringUtils.isEmpty(systemPropertyName)) {

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/InputsTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/InputsTransformerTest.java
@@ -105,7 +105,7 @@ public class InputsTransformerTest {
         @SuppressWarnings("unchecked") List<Input> inputs = inputTransformer.transform(inputsMap);
         Input input = inputs.get(4);
         Assert.assertEquals("input5", input.getName());
-        Assert.assertEquals("input5", input.getExpression());
+        Assert.assertEquals(null, input.getExpression());
         Assert.assertEquals(true, input.isEncrypted());
         Assert.assertEquals(true, input.isRequired());
     }


### PR DESCRIPTION
Fixes #336 
When no default value is specified, do not put the name of the input as it's expression (for the case where the input has additional properties)

Signed-off-by: Orit Stone <orit.stone@hp.com>