### PR TITLE
Fix the test case name null in the builder

### DIFF
--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
@@ -76,8 +76,9 @@ public class SlangTestRunner {
                     "file path \'" + testCaseFile.getAbsolutePath() + "\' must lead to a file");
 
             Map<String, SlangTestCase> testCasesFromCurrentFile = parser.parseTestCases(SlangSource.fromFile(testCaseFile));
-            for (SlangTestCase currentTestCase : testCasesFromCurrentFile.values()) {
-                String currentTestCaseName = currentTestCase.getName();
+            for (Map.Entry<String, SlangTestCase> currentTestCaseEntry : testCasesFromCurrentFile.entrySet()) {
+                SlangTestCase currentTestCase = currentTestCaseEntry.getValue();
+                String currentTestCaseName = currentTestCaseEntry.getKey();
                 //todo: temporary solution
                 currentTestCase.setName(currentTestCaseName);
                 if(StringUtils.isBlank(currentTestCase.getResult())){

--- a/cloudslang-content-verifier/src/main/resources/log4j.properties
+++ b/cloudslang-content-verifier/src/main/resources/log4j.properties
@@ -6,7 +6,7 @@ log4j.rootLogger=ERROR,CONSOLE, FA
 #Console Appender
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=[%p] %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{hh:mm:ss} [%p] %m%n
 log4j.appender.CONSOLE.Threshold=INFO
 
 
@@ -14,7 +14,7 @@ log4j.appender.CONSOLE.Threshold=INFO
 log4j.appender.FA=org.apache.log4j.RollingFileAppender
 log4j.appender.FA.File=builder.log
 log4j.appender.FA.layout=org.apache.log4j.PatternLayout
-log4j.appender.FA.layout.ConversionPattern=[%p] %m%n
+log4j.appender.FA.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} [%p] %m%n
 log4j.appender.FA.Threshold=DEBUG
 
 log4j.logger.io.cloudslang.lang.tools.build=DEBUG

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
@@ -120,7 +120,7 @@ public class SlangTestRunnerTest {
 
     @Test
     public void createTestCaseWithDuplicateName() throws Exception {
-        URI resource = getClass().getResource("/test/valid").toURI();
+        URI resource = getClass().getResource("/test/duplicate").toURI();
         Map<String, SlangTestCase> testCases = new HashMap<>();
         testCases.put("Test1", new SlangTestCase("Test1", "path", "desc", null, null, null, null, null, null));
         testCases.put("Test2", new SlangTestCase("Test1", "path2", "desc2", null, null, null, null, null, null));

--- a/cloudslang-content-verifier/src/test/resources/test/duplicate/test_cases_1.yaml
+++ b/cloudslang-content-verifier/src/test/resources/test/duplicate/test_cases_1.yaml
@@ -1,0 +1,13 @@
+testPrintPropertyWithTextInput:
+  inputs:
+    - text: text to print
+  description: Tests that print_text operation finishes with SUCCESS
+  testFlowPath: base.print_property
+  result: SUCCESS
+
+testPrintPropertyWithSysProperty:
+  description: Tests that print_text operation finishes with SUCCESS
+  systemPropertiesFile: ${project_path}\content\base\properties.yaml
+  testFlowPath: base.print_property
+  throwsException: false
+

--- a/cloudslang-content-verifier/src/test/resources/test/duplicate/test_cases_2.yaml
+++ b/cloudslang-content-verifier/src/test/resources/test/duplicate/test_cases_2.yaml
@@ -1,0 +1,16 @@
+testPrintPropertyWithTextInput:
+  inputs:
+    - text: text to print
+  description: Tests that print_text operation finishes with SUCCESS
+  testFlowPath: base.print_property
+  result: SUCCESS
+
+testOutputTextOp:
+  inputs:
+    - text: text to print
+  description: Tests outputs
+  testFlowPath: base.output_op
+  result: SUCCESS
+  outputs:
+    - output_text1: text to print
+    - output_text2: second output


### PR DESCRIPTION
Fixes #376 

- Take test case name from the key of the test cases map
- Fix logging -> to add timestamp

Signed-off-by: Orit Stone <orit.stone@hp.com>