### PR TITLE
Dont import jython site - try to improve a bit CLI start time

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/configuration/SlangRuntimeSpringConfig.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/configuration/SlangRuntimeSpringConfig.java
@@ -11,6 +11,7 @@ package io.cloudslang.lang.runtime.configuration;
 *******************************************************************************/
 
 
+import org.python.core.Options;
 import org.python.util.PythonInterpreter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -22,6 +23,10 @@ import javax.script.ScriptEngineManager;
 @Configuration
 @ComponentScan("io.cloudslang.lang.runtime")
 public class SlangRuntimeSpringConfig {
+
+    static {
+        Options.importSite = false;
+    }
 
     @Bean
     public PythonInterpreter interpreter(){

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
             <dependency>
                 <groupId>org.python</groupId>
                 <artifactId>jython-standalone</artifactId>
-                <version>2.7-rc3</version>
+                <version>2.7.0</version>
                 <scope>compile</scope>
             </dependency>
 


### PR DESCRIPTION
Partially helps for #294 

The purpose of this change is to improve startup performance of the cslang CLI
According to jython java docs when this property is set to false site.py will not be imported
AFAIK this site packages doesn't exist unless you install jython (and not embedding) 