### PR TITLE
Fix the inputs binding event to keep the order of the inputs

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/AbstractSteps.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/AbstractSteps.java
@@ -19,7 +19,7 @@ import io.cloudslang.score.lang.ExecutionRuntimeServices;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -47,7 +47,7 @@ public abstract class AbstractSteps {
                                           String desc,
                                           LanguageEventData.StepType stepType,
                                           String stepName) {
-        Map<String, Serializable> inputsForEvent = new HashMap<>();
+        Map<String, Serializable> inputsForEvent = new LinkedHashMap<>();
         for (Input input : inputs) {
             String inputName = input.getName();
             Serializable inputValue = context.get(inputName);

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/OutputsBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/OutputsBindingTest.java
@@ -14,6 +14,7 @@ import io.cloudslang.lang.entities.bindings.Output;
 import junit.framework.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.python.google.common.collect.Lists;
 import org.python.util.PythonInterpreter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -24,11 +25,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Date: 11/7/2014
@@ -117,6 +114,24 @@ public class OutputsBindingTest {
         expectedOutputs.put("hostFromExpression", "http://hostExpr:9999");
 
         Assert.assertEquals("Binding results are not as expected", expectedOutputs, result);
+    }
+
+    @Test(timeout = DEFAULT_TIMEOUT)
+    public void testOutputsRetainOrder() {
+        Map<String, Serializable> operationContext = prepareOperationContext();
+        Map<String, Serializable> actionReturnValues = prepareActionReturnValues();
+        List<Output> outputs = Lists.newArrayList(
+                createExpressionOutput("output1", "1"),
+                createExpressionOutput("output2", "2"),
+                createExpressionOutput("output3", "3")
+        );
+
+        Map<String, Serializable> result = outputsBinding.bindOutputs(operationContext, actionReturnValues, outputs);
+
+        List<String> actualInputNames = Lists.newArrayList(result.keySet());
+        List<String> expectedInputNames = Lists.newArrayList("output1", "output2", "output3");
+
+        Assert.assertEquals("Binding results are not as expected", expectedInputNames, actualInputNames);
     }
 
     @Test(expected = RuntimeException.class)

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
@@ -35,12 +35,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.script.ScriptEngine;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyMapOf;
@@ -115,12 +110,22 @@ public class ExecutableStepsTest {
         LanguageEventData eventData = (LanguageEventData)boundInputEvent.getData();
         Assert.assertTrue(eventData.containsKey(LanguageEventData.BOUND_INPUTS));
         Map<String,Serializable> inputsBounded = (Map<String,Serializable>)eventData.get(LanguageEventData.BOUND_INPUTS);
-        Assert.assertEquals(5, inputsBounded.get("input1"));
-        Assert.assertEquals(LanguageEventData.ENCRYPTED_VALUE,inputsBounded.get("input2"));
 
         Assert.assertNotNull(eventData.getStepName());
         Assert.assertEquals(LanguageEventData.StepType.EXECUTABLE, eventData.getStepType());
         Assert.assertEquals("dockerizeStep", eventData.getStepName());
+
+        // verify input names are in defined order and have the expected value
+        Set<Map.Entry<String, Serializable>> inputEntries = inputsBounded.entrySet();
+        Iterator<Map.Entry<String, Serializable>> inputNamesIterator = inputEntries.iterator();
+
+        Map.Entry<String, Serializable> firstInput =  inputNamesIterator.next();
+        org.junit.Assert.assertEquals("Inputs are not in defined order in end inputs binding event", "input1", firstInput.getKey());
+        org.junit.Assert.assertEquals(5, firstInput.getValue());
+
+        Map.Entry<String, Serializable> secondInput =  inputNamesIterator.next();
+        org.junit.Assert.assertEquals("Inputs are not in defined order in end inputs binding event", "input2", secondInput.getKey());
+        org.junit.Assert.assertEquals(LanguageEventData.ENCRYPTED_VALUE, secondInput.getValue());
     }
 
     @Test

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/TaskStepsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/TaskStepsTest.java
@@ -32,6 +32,7 @@ import io.cloudslang.lang.runtime.bindings.ScriptEvaluator;
 import io.cloudslang.lang.runtime.env.Context;
 import io.cloudslang.lang.runtime.env.ParentFlowData;
 import io.cloudslang.lang.runtime.env.RunEnvironment;
+import org.python.google.common.collect.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,13 +41,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.script.ScriptEngine;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyMap;
@@ -150,25 +145,41 @@ public class TaskStepsTest {
 
         LanguageEventData startBindingEventData = (LanguageEventData)inputStartEvent.getData();
         Assert.assertEquals("task1",startBindingEventData.getStepName());
-        Assert.assertEquals(LanguageEventData.StepType.TASK,startBindingEventData.getStepType());
+        Assert.assertEquals(LanguageEventData.StepType.TASK, startBindingEventData.getStepType());
 
+        @SuppressWarnings("unchecked")
         List<String> inputsToBind = (List<String>)startBindingEventData.get(LanguageEventData.INPUTS);
-        Assert.assertTrue(inputsToBind.contains("input1"));
-        Assert.assertTrue(inputsToBind.contains("input2"));
+        Assert.assertEquals(
+                "Inputs are not in defined order in start binding event",
+                Lists.newArrayList("input1", "input2"),
+                inputsToBind
+        );
 
         LanguageEventData eventData = (LanguageEventData)inputEndEvent.getData();
         Assert.assertEquals("task1",eventData.getStepName());
         Assert.assertEquals(LanguageEventData.StepType.TASK,eventData.getStepType());
 
-        Map<String,Serializable> boundInputs = (Map<String,Serializable>)eventData.get(LanguageEventData.BOUND_INPUTS);
-        Assert.assertEquals(5,boundInputs.get("input1"));
-        Assert.assertEquals(3,boundInputs.get("input2"));
+        @SuppressWarnings("unchecked")
+        Map<String, Serializable> boundInputs = (Map<String,Serializable>)eventData.get(LanguageEventData.BOUND_INPUTS);
+        Assert.assertEquals(2, boundInputs.size());
+
+        // verify input names are in defined order and have the expected value
+        Set<Map.Entry<String, Serializable>> inputEntries = boundInputs.entrySet();
+        Iterator<Map.Entry<String, Serializable>> inputNamesIterator = inputEntries.iterator();
+
+        Map.Entry<String, Serializable> firstInput =  inputNamesIterator.next();
+        Assert.assertEquals("Inputs are not in defined order in end inputs binding event", "input1", firstInput.getKey());
+        Assert.assertEquals(5,firstInput.getValue());
+
+        Map.Entry<String, Serializable> secondInput =  inputNamesIterator.next();
+        Assert.assertEquals("Inputs are not in defined order in end inputs binding event", "input2", secondInput.getKey());
+        Assert.assertEquals(3,secondInput.getValue());
     }
 
     @Test
     public void testEndTaskEvents() throws Exception {
         RunEnvironment runEnv = createRunEnvironment();
-        runEnv.putReturnValues(new ReturnValues(new HashMap<String,Serializable>(), ScoreLangConstants.SUCCESS_RESULT));
+        runEnv.putReturnValues(new ReturnValues(new HashMap<String, Serializable>(), ScoreLangConstants.SUCCESS_RESULT));
         Context context = new Context(new HashMap<String, Serializable>());
         runEnv.getStack().pushContext(context);
 


### PR DESCRIPTION
Fixes #357 

Signed-off-by: Orit Stone <orit.stone@hp.com>