### PR TITLE
Builder: the logs folder is not located in the right place

### DIFF
--- a/cloudslang-content-verifier/src/main/resources/log4j.properties
+++ b/cloudslang-content-verifier/src/main/resources/log4j.properties
@@ -12,7 +12,7 @@ log4j.appender.CONSOLE.Threshold=INFO
 
 #File appender
 log4j.appender.FA=org.apache.log4j.RollingFileAppender
-log4j.appender.FA.File=builder.log
+log4j.appender.FA.File=${app.home}/logs/builder.log
 log4j.appender.FA.layout=org.apache.log4j.PatternLayout
 log4j.appender.FA.layout.ConversionPattern=%d{dd/MM/yy HH:mm:ss} [%p] %m%n
 log4j.appender.FA.Threshold=DEBUG


### PR DESCRIPTION
fixes #494 

Signed-off-by: Maayan Avraham maayan.avraham@hpe.com