### PR TITLE
fix cli options

### DIFF
--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangCLI.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangCLI.java
@@ -68,8 +68,8 @@ public class SlangCLI implements CommandMarker {
             @CliOption(key = {"cp", "classpath"}, mandatory = false, help = "Classpath , a directory comma separated list to flow dependencies, by default it will take flow file dir") final List<String> classPath,
             @CliOption(key = {"i", "inputs"}, mandatory = false, help = "inputs in a key=value comma separated list") final Map<String,? extends Serializable> inputs,
             @CliOption(key = {"if", "input-file"}, mandatory = false, help = "comma separated list of input file locations") final List<String> inputFiles,
-            @CliOption(key = {"", "q", "quiet"}, mandatory = false, help = "quiet", specifiedDefaultValue = "true",unspecifiedDefaultValue = "false") final Boolean quiet,
-            @CliOption(key = {"", "d", "debug"}, mandatory = false, help = "print each task outputs", specifiedDefaultValue = "true",unspecifiedDefaultValue = "false") final Boolean debug,
+            @CliOption(key = {"q", "quiet"}, mandatory = false, help = "quiet", specifiedDefaultValue = "true",unspecifiedDefaultValue = "false") final Boolean quiet,
+            @CliOption(key = {"d", "debug"}, mandatory = false, help = "print each task outputs", specifiedDefaultValue = "true",unspecifiedDefaultValue = "false") final Boolean debug,
             @CliOption(key = {"spf", "system-property-file"}, mandatory = false, help = "comma separated list of system property file locations") final List<String> systemPropertyFiles) throws IOException {
 
         CompilationArtifact compilationArtifact = compilerHelper.compile(file.getAbsolutePath(), classPath);


### PR DESCRIPTION
from doc: 
```
	/**
	 * @return the name of the option, which must be unique within this {@link CliCommand} (an empty String may
	 * be given, which would denote this option is the default for the command)
	 */
	String[] key();
```

which means we can have `""` only for one CLI option - which promotes the option as main option for the cmd so we can do this:
```
run path/to/flow
```
which is equivalent to 
```
run --f  path/to/flow
```
or
```
run --file  path/to/flow
```

Signed-off-by: Bonczidai Levente <levente.bonczidai@hpe.com>