### PR TITLE
Spring-io changes for cloudslang 0.8

### DIFF
--- a/cloudslang-content-verifier/pom.xml
+++ b/cloudslang-content-verifier/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.48</version>
+            <version>1.35</version>
         </dependency>
 
         <!-- content dep -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <score.group>io.cloudslang</score.group>
-        <score.version>0.2.2</score.version>
-        <spring.version>4.1.4.RELEASE</spring.version>
+        <score.version>0.2.3</score.version>
+        <spring.version>4.1.7.RELEASE</spring.version>
     </properties>
 
     <distributionManagement>
@@ -184,7 +184,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.2</version>
+                <version>1.7.12</version>
                 <scope>runtime</scope>
             </dependency>
 
@@ -197,7 +197,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.3</version>
+                <version>2.4</version>
             </dependency>
 
             <dependency>
@@ -209,7 +209,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>15.0</version>
+                <version>17.0</version>
             </dependency>
 
             <dependency>
@@ -258,7 +258,7 @@
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
-                <version>2.0.5</version>
+                <version>3.3.5</version>
             </dependency>
 
             <dependency>
@@ -271,7 +271,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.183</version>
+                <version>1.4.187</version>
                 <scope>test</scope>
             </dependency>
 
@@ -293,20 +293,20 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.10.17</version>
+                <version>1.10.8</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.5.1</version>
+                <version>2.4.6</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.2.4</version>
+                <version>2.3.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Update score to 0.2.3
Spring-io changes for cloud slang 0.8
Signed-off-by: Lucian Musca <lucian-cristian.musca@hpe.com>