### PR TITLE
Add validate model with dependencies

### DIFF
--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompiler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompiler.java
@@ -48,8 +48,8 @@ public interface SlangCompiler {
      * Validate that the given {@Link io.cloudslang.lang.compiler.modeller.model.Executable} is valid regarding
      * its wiring to its dependencies
      * Current validations:
-     *      - Validates that required inputs of the dependecy have a matching input in the task
-     *      - Validate that every result of teh dependency has a matching navigation in the task
+     *      - Validates that required inputs of the dependency have a matching input in the step
+     *      - Validate that every result of teh dependency has a matching navigation in the step
      * @param slangModel the CloudSlang model to validate
      * @param dependenciesModels the CloudSlang models of the direct dependencies
      * @return a list of the exceptions that were found (if any)

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompiler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompiler.java
@@ -13,6 +13,7 @@ import io.cloudslang.lang.compiler.modeller.result.ExecutableModellingResult;
 import io.cloudslang.lang.entities.CompilationArtifact;
 import io.cloudslang.lang.entities.SystemProperty;
 
+import java.util.List;
 import java.util.Set;
 
 public interface SlangCompiler {
@@ -43,6 +44,15 @@ public interface SlangCompiler {
      */
     ExecutableModellingResult preCompileSource(SlangSource source);
 
-    Set<SystemProperty> loadSystemProperties(SlangSource source);
-
+    /**
+     * Validate that the given {@Link io.cloudslang.lang.compiler.modeller.model.Executable} is valid regarding
+     * its wiring to its dependencies
+     * Current validations:
+     *      - Validates that required inputs of the dependecy have a matching input in the task
+     *      - Validate that every result of teh dependency has a matching navigation in the task
+     * @param slangModel the CloudSlang model to validate
+     * @param dependenciesModels the CloudSlang models of the direct dependencies
+     * @return a list of the exceptions that were found (if any)
+     */
+    List<RuntimeException> validateSlangModelWithDependencies(Executable slangModel, Set<Executable> dependenciesModels);
 }

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompiler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompiler.java
@@ -55,4 +55,7 @@ public interface SlangCompiler {
      * @return a list of the exceptions that were found (if any)
      */
     List<RuntimeException> validateSlangModelWithDependencies(Executable slangModel, Set<Executable> dependenciesModels);
+
+    Set<SystemProperty> loadSystemProperties(SlangSource source);
+
 }

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompilerImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompilerImpl.java
@@ -90,6 +90,11 @@ public class SlangCompilerImpl implements SlangCompiler {
     }
 
     @Override
+    public List<RuntimeException> validateSlangModelWithDependencies(Executable slangModel, Set<Executable> dependenciesModels) {
+        return scoreCompiler.validateSlangModelWithDependencies(slangModel,dependenciesModels);
+    }
+
+    @Override
     public Set<SystemProperty> loadSystemProperties(SlangSource source) {
         try {
             ParsedSlang parsedSlang = parseSystemPropertiesFile(source);

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ScoreCompiler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ScoreCompiler.java
@@ -40,8 +40,8 @@ public interface ScoreCompiler {
      * Validate that the given {@Link io.cloudslang.lang.compiler.modeller.model.Executable} is valid regarding
      * its wiring to its dependencies
      * Current validations:
-     *      - Validates that required inputs of the dependecy have a matching input in the task
-     *      - Validate that every result of teh dependency has a matching navigation in the task
+     *      - Validates that required inputs of the dependency have a matching input in the step
+     *      - Validate that every result of teh dependency has a matching navigation in the step
      * @param slangModel the CloudSlang model to validate
      * @param dependenciesModels the CloudSlang models of the direct dependencies
      * @return a list of the exceptions that were found (if any)

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ScoreCompiler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ScoreCompiler.java
@@ -11,6 +11,7 @@ package io.cloudslang.lang.compiler.scorecompiler;
 import io.cloudslang.lang.compiler.modeller.model.Executable;
 import io.cloudslang.lang.entities.CompilationArtifact;
 
+import java.util.List;
 import java.util.Set;
 
 /*
@@ -20,7 +21,7 @@ import java.util.Set;
 /**
  * Score Compiler - compiles CloudSlang {@link io.cloudslang.lang.compiler.modeller.model.Executable} model
  * to a {@link io.cloudslang.lang.entities.CompilationArtifact}
- * {@link io.cloudslang.lang.entities.CompilationArtifact} is an object holding an {@link io.cloudslang.api.ExecutionPlan}:
+ * {@link io.cloudslang.lang.entities.CompilationArtifact} is an object holding an {@link io.cloudslang.score.api.ExecutionPlan}:
  * compilation result of a workflow
  * in the score format. This object can be run on score engine.
  */
@@ -34,5 +35,17 @@ public interface ScoreCompiler {
      * @return the compiled {@link io.cloudslang.lang.entities.CompilationArtifact}
      */
     CompilationArtifact compile(Executable source, Set<Executable> path);
+
+    /**
+     * Validate that the given {@Link io.cloudslang.lang.compiler.modeller.model.Executable} is valid regarding
+     * its wiring to its dependencies
+     * Current validations:
+     *      - Validates that required inputs of the dependecy have a matching input in the task
+     *      - Validate that every result of teh dependency has a matching navigation in the task
+     * @param slangModel the CloudSlang model to validate
+     * @param dependenciesModels the CloudSlang models of the direct dependencies
+     * @return a list of the exceptions that were found (if any)
+     */
+    List<RuntimeException> validateSlangModelWithDependencies(Executable slangModel, Set<Executable> dependenciesModels);
 
 }

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileBasicFlowTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileBasicFlowTest.java
@@ -130,6 +130,21 @@ public class CompileBasicFlowTest {
     }
 
     @Test
+    public void testValidateSlangModelWithDependenciesBasic() throws Exception {
+        URI flowUri = getClass().getResource("/basic_flow.yaml").toURI();
+        Executable flow = compiler.preCompile(SlangSource.fromFile(flowUri));
+
+        URI operationUri = getClass().getResource("/test_op.sl").toURI();
+        Executable op = compiler.preCompile(SlangSource.fromFile(operationUri));
+
+        Set<Executable> dependencies = new HashSet();
+        dependencies.add(op);
+        List<RuntimeException> errors = compiler.validateSlangModelWithDependencies(flow, dependencies);
+
+        Assert.assertEquals("", 0, errors.size());
+    }
+
+    @Test
     public void testCompileFlowNavigateDuplicateKeysFirstIsTaken() throws Exception {
         URI flow = getClass().getResource("/flow_navigate_duplicate_keys.sl").toURI();
         URI operation = getClass().getResource("/check_Weather.sl").toURI();

--- a/cloudslang-compiler/src/test/resources/corrupted/flow_missing_dependency_required_input_in_step.sl
+++ b/cloudslang-compiler/src/test/resources/corrupted/flow_missing_dependency_required_input_in_step.sl
@@ -7,10 +7,20 @@
 
 namespace: io.cloudslang
 
-operation:
-  name: check_op
-  inputs:
-    - alla:
-        ${get_sp('user.sys.props.alla')}
-  action:
-    python_script: 'print "hello world"'
+imports:
+  ops: user.ops
+
+flow:
+  name: flow_missing_dependency_required_input_in_step
+  workflow:
+    - explicit_alias:
+        do:
+          ops.test_op:
+            - city: 'input_1'
+            - port: '22'
+
+    - implicit_alias:
+        do:
+          check_op:
+            - city: 'input_1'
+            - port: '22'


### PR DESCRIPTION
Add a new method to the Slang compiler API that allows to validate an Executable model against the models of it dependencies
For now we validate:
- That all the results of the dependency have matching navigations in the step
- That all required inputs of the dependency with no default value, have matching inputs in the task