### PR TITLE
Change the file encoding used for reading Slang sources, from the JRE…

### DIFF
--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangSource.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangSource.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class SlangSource {
 
@@ -56,10 +57,9 @@ public class SlangSource {
 
     private static Charset getCharset() {
         String cslangEncoding = System.getProperty(SlangSystemPropertyConstant.CSLANG_ENCODING.getValue());
-        if (StringUtils.isEmpty(cslangEncoding)) {
-            cslangEncoding = "UTF-8";
-        }
-        return Charset.forName(cslangEncoding);
+        return StringUtils.isEmpty(cslangEncoding) ?
+                StandardCharsets.UTF_8 :
+                Charset.forName(cslangEncoding);
     }
 
     public static SlangSource fromFile(URI uri) {

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangSource.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangSource.java
@@ -55,12 +55,11 @@ public class SlangSource {
     }
 
     private static Charset getCharset() {
-        Charset charset = Charset.defaultCharset();
         String cslangEncoding = System.getProperty(SlangSystemPropertyConstant.CSLANG_ENCODING.getValue());
-        if (!StringUtils.isEmpty(cslangEncoding)) {
-            charset = Charset.forName(cslangEncoding);
+        if (StringUtils.isEmpty(cslangEncoding)) {
+            cslangEncoding = "UTF-8";
         }
-        return charset;
+        return Charset.forName(cslangEncoding);
     }
 
     public static SlangSource fromFile(URI uri) {

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/configuration/SlangRuntimeSpringConfig.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/configuration/SlangRuntimeSpringConfig.java
@@ -32,7 +32,9 @@ public class SlangRuntimeSpringConfig {
 
     private static void setPythonIOEncoding() {
         String encodingValue = System.getProperty(SlangSystemPropertyConstant.CSLANG_ENCODING.getValue());
-        if (!StringUtils.isEmpty(encodingValue))
-            System.getProperties().setProperty(PySystemState.PYTHON_IO_ENCODING, encodingValue);
+        if (StringUtils.isEmpty(encodingValue)) {
+            encodingValue = "UTF-8";
+        }
+        System.getProperties().setProperty(PySystemState.PYTHON_IO_ENCODING, encodingValue);
     }
 }

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/configuration/SlangRuntimeSpringConfig.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/configuration/SlangRuntimeSpringConfig.java
@@ -20,6 +20,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import java.nio.charset.StandardCharsets;
+
 @Configuration
 @Import({RuntimeManagementConfiguration.class})
 @ComponentScan("io.cloudslang.lang.runtime")
@@ -33,7 +35,7 @@ public class SlangRuntimeSpringConfig {
     private static void setPythonIOEncoding() {
         String encodingValue = System.getProperty(SlangSystemPropertyConstant.CSLANG_ENCODING.getValue());
         if (StringUtils.isEmpty(encodingValue)) {
-            encodingValue = "UTF-8";
+            encodingValue = StandardCharsets.UTF_8.name();
         }
         System.getProperties().setProperty(PySystemState.PYTHON_IO_ENCODING, encodingValue);
     }

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SystemsTestsParent.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SystemsTestsParent.java
@@ -16,12 +16,18 @@ import io.cloudslang.lang.api.Slang;
 import io.cloudslang.lang.compiler.SlangCompiler;
 import io.cloudslang.lang.compiler.SlangSource;
 import io.cloudslang.lang.entities.CompilationArtifact;
-import io.cloudslang.lang.entities.SlangSystemPropertyConstant;
 import io.cloudslang.lang.entities.SystemProperty;
 import io.cloudslang.lang.entities.bindings.values.SensitiveValue;
 import io.cloudslang.lang.entities.bindings.values.Value;
 import io.cloudslang.runtime.impl.python.PythonExecutionNotCachedEngine;
 import io.cloudslang.score.events.ScoreEvent;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -29,12 +35,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static ch.lambdaj.Lambda.select;
 import static org.hamcrest.Matchers.startsWith;
@@ -101,10 +101,6 @@ public abstract class SystemsTestsParent {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    static {
-        System.setProperty(SlangSystemPropertyConstant.CSLANG_ENCODING.getValue(), "utf-8");
-    }
-
     protected ScoreEvent trigger(CompilationArtifact compilationArtifact, Map<String, Value> userInputs, Set<SystemProperty> systemProperties) {
         return triggerFlows.runSync(compilationArtifact, userInputs, systemProperties);
     }
@@ -140,5 +136,4 @@ public abstract class SystemsTestsParent {
             }
         }
     }
-
 }


### PR DESCRIPTION
… default (which in many cases is a regional charset, 1990s-style) to the modern UTF-8. Note: As before, this can be overridden with the "cslang.encoding" system property (though it is probably a better idea to just use UTF-8 in all sources).