### PR TITLE
Adding dependency checker for all cloudslang modules

### DIFF
--- a/cloudslang-all/pom.xml
+++ b/cloudslang-all/pom.xml
@@ -55,5 +55,37 @@ http://www.apache.org/licenses/LICENSE-2.0
 
     </dependencies>
 
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <!--For detection of used undeclared dependencies currently everything here is ignore because of existing issue to not fail the build now.-->
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>log4j:log4j:jar:1.2.17</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-context:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.hamcrest:hamcrest-all:jar:1.1</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang:score-api:jar:0.3.40</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>com.googlecode.lambdaj:lambdaj:jar:2.3.3</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-entities:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 
 </project>

--- a/cloudslang-cli/pom.xml
+++ b/cloudslang-cli/pom.xml
@@ -142,7 +142,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
                 <executions>
                     <execution>
                         <id>unpack</id>
@@ -162,6 +161,45 @@
                                     <destFileName>maven</destFileName>
                                 </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <!--For detection of used undeclared dependencies currently everything here is ignore because of existing issue to not fail the build now.-->
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-runtime:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-entities:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-all:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-compiler:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>log4j:log4j:jar:1.2.17</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.powermock:powermock-core:jar:1.6.5</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-core:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-context:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.powermock:powermock-core:jar:1.6.5</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.hamcrest:hamcrest-all:jar:1.3</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>com.googlecode.lambdaj:lambdaj:jar:2.3.3</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.apache.commons:commons-lang3:jar:3.3.2</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-io:commons-io:jar:2.4</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.apache.commons:commons-collections4:jar:4.1</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.yaml:snakeyaml:jar:1.16</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>com.google.guava:guava:jar:17.0</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang:score-api:jar:0.3.40</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-collections:commons-collections:jar:3.2.2</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/cloudslang-commons/pom.xml
+++ b/cloudslang-commons/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
@@ -22,4 +23,30 @@
             <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>org.apache.commons:commons-lang3:jar:3.3.2</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-context:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-entities:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/cloudslang-compiler/pom.xml
+++ b/cloudslang-compiler/pom.xml
@@ -71,4 +71,34 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang:score-api:jar:0.3.40</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.apache.commons:commons-lang3:jar:3.3.2</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.python:jython-standalone:jar:2.7.0</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-core:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.hamcrest:hamcrest-all:jar:1.1</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.apache.commons:commons-collections4:jar:4.1</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/cloudslang-content-maven-compiler/pom.xml
+++ b/cloudslang-content-maven-compiler/pom.xml
@@ -55,6 +55,30 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>org.codehaus.plexus:plexus-component-annotations:jar:1.5.5</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.codehaus.plexus:plexus-utils:jar:3.0.10</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-io:commons-io:jar:2.4</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.apache.commons:commons-collections4:jar:4.1</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-context:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/cloudslang-content-verifier/pom.xml
+++ b/cloudslang-content-verifier/pom.xml
@@ -124,7 +124,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
                 <executions>
                     <execution>
                         <id>unpack</id>
@@ -144,6 +143,37 @@
                                     <destFileName>maven</destFileName>
                                 </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>log4j:log4j:jar:1.2.17</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-runtime:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-core:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-context:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>com.fasterxml.jackson.core:jackson-annotations:jar:2.6.0</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang:score-api:jar:0.3.40</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.python:jython-standalone:jar:2.7.0</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-collections:commons-collections:jar:3.2.2</ignoredUsedUndeclaredDependency>
+
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-all:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-entities:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-compiler:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/cloudslang-entities/pom.xml
+++ b/cloudslang-entities/pom.xml
@@ -89,4 +89,30 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>com.fasterxml.jackson.core:jackson-annotations:jar:2.6.0</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/cloudslang-runtime/pom.xml
+++ b/cloudslang-runtime/pom.xml
@@ -97,4 +97,31 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoredUsedUndeclaredDependencies>
+                                <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-spi:jar:0.9.75-SNAPSHOT</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency> org.apache.commons:commons-collections4:jar:4.1</ignoredUsedUndeclaredDependency>
+                            </ignoredUsedUndeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/cloudslang-spi/pom.xml
+++ b/cloudslang-spi/pom.xml
@@ -17,4 +17,24 @@
 
     <artifactId>cloudslang-spi</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/cloudslang-tests/pom.xml
+++ b/cloudslang-tests/pom.xml
@@ -92,6 +92,24 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
+                <executions>
+                    <execution>
+                        <id>analyze dependencies</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>false</failOnWarning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>2.8</version>
                     <executions>
                         <execution>
                             <id>analyze dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.8</version>
+                    <version>2.10</version>
                     <executions>
                         <execution>
                             <id>analyze dependencies</id>
@@ -504,32 +504,6 @@
                                 <failOnWarning>true</failOnWarning>
                                 <!--For detection of used undeclared dependencies currently everything here is ignore because of existing issue to not fail the build now.-->
                                 <ignoredUsedUndeclaredDependencies combine.children="append">
-                                    <ignoredUsedUndeclaredDependency>log4j:log4j:jar:1.2.17</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-runtime:jar:${project.version}</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-compiler:jar:${project.version}</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-all:jar:${project.version}</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-entities:jar:${project.version}</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>io.cloudslang:score-api:jar:0.3.40</ignoredUsedUndeclaredDependency>
-
-                                    <!--Spring related-->
-                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-core:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-context:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
-
-                                    <!--Other third parties-->
-                                    <ignoredUsedUndeclaredDependency>com.fasterxml.jackson.core:jackson-annotations:jar:2.6.0</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>com.google.guava:guava:jar:17.0</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>org.python:jython-standalone:jar:2.7.0</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>commons-collections:commons-collections:jar:3.2.2</ignoredUsedUndeclaredDependency>
-
-                                    <ignoredUsedUndeclaredDependency>org.powermock:powermock-core:jar:1.6.5</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>commons-io:commons-io:jar:2.4</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>org.apache.commons:commons-collections4:jar:4.1</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>org.apache.commons:commons-lang3:jar:3.3.2</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>org.yaml:snakeyaml:jar:1.16</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>com.googlecode.lambdaj:lambdaj:jar:2.3.3</ignoredUsedUndeclaredDependency>
-                                    <ignoredUsedUndeclaredDependency>org.hamcrest:hamcrest-all:jar:1.3</ignoredUsedUndeclaredDependency>
                                 </ignoredUsedUndeclaredDependencies>
 
                                 <ignoredUnusedDeclaredDependencies combine.children="append">
@@ -539,6 +513,8 @@
 
                                     <ignoredUnusedDeclaredDependency>org.python:jython-standalone:jar:2.7.0</ignoredUnusedDeclaredDependency>
                                     <ignoredUnusedDeclaredDependency>org.liquibase:liquibase-core:jar:3.4.2</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>log4j:log4j:jar:1.2.17</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.3.1</ignoredUnusedDeclaredDependency>
                                 </ignoredUnusedDeclaredDependencies>
 
                             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,63 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.10</version>
+                    <executions>
+                        <execution>
+                            <id>analyze dependencies</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                                <!--For detection of used undeclared dependencies currently everything here is ignore because of existing issue to not fail the build now.-->
+                                <ignoredUsedUndeclaredDependencies combine.children="append">
+                                    <ignoredUsedUndeclaredDependency>log4j:log4j:jar:1.2.17</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-runtime:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-compiler:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-all:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-entities:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang:score-api:jar:0.3.40</ignoredUsedUndeclaredDependency>
+
+                                    <!--Spring related-->
+                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-core:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-context:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+
+                                    <!--Other third parties-->
+                                    <ignoredUsedUndeclaredDependency>com.fasterxml.jackson.core:jackson-annotations:jar:2.6.0</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>com.google.guava:guava:jar:17.0</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.python:jython-standalone:jar:2.7.0</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>commons-collections:commons-collections:jar:3.2.2</ignoredUsedUndeclaredDependency>
+
+                                    <ignoredUsedUndeclaredDependency>org.powermock:powermock-core:jar:1.6.5</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>commons-io:commons-io:jar:2.4</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.apache.commons:commons-collections4:jar:4.1</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.apache.commons:commons-lang3:jar:3.3.2</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.yaml:snakeyaml:jar:1.16</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>com.googlecode.lambdaj:lambdaj:jar:2.3.3</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.hamcrest:hamcrest-all:jar:1.3</ignoredUsedUndeclaredDependency>
+                                </ignoredUsedUndeclaredDependencies>
+
+                                <ignoredUnusedDeclaredDependencies combine.children="append">
+                                    <ignoredUnusedDeclaredDependency>io.cloudslang:score-all:jar:0.3.40</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>com.mattbertolini:liquibase-slf4j:jar:1.2.1</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>com.h2database:h2:jar:1.4.191</ignoredUnusedDeclaredDependency>
+
+                                    <ignoredUnusedDeclaredDependency>org.python:jython-standalone:jar:2.7.0</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>org.liquibase:liquibase-core:jar:3.4.2</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
Fix for #890
Introduce a mechanism to fail the build in case of undeclared dependencies which are used.
Also introduced a mechanism to fail the build in case of used but declared. This might produce several false positives so for now we will mostly investigate such findings adding them in the ignore list.

Signed-off-by: Lucian Musca <lucian-cristian.musca@hpe.com>