### PR TITLE
Adding dependency checker for all cloudslang modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,62 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.10</version>
+                    <executions>
+                        <execution>
+                            <id>analyze dependencies</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <failOnWarning>true</failOnWarning>
+                                <!--For detection of used undeclared dependencies currently everything here is ignore because of existing issue to not fail the build now.-->
+                                <ignoredUsedUndeclaredDependencies combine.children="append">
+                                    <ignoredUsedUndeclaredDependency>log4j:log4j:jar:1.2.17</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-runtime:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-compiler:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-all:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang.lang:cloudslang-entities:jar:${project.version}</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>io.cloudslang:score-api:jar:0.3.40</ignoredUsedUndeclaredDependency>
+
+                                    <!--Spring related-->
+                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-core:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-context:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.springframework:spring-beans:jar:4.2.5.RELEASE</ignoredUsedUndeclaredDependency>
+
+                                    <!--Other third parties-->
+                                    <ignoredUsedUndeclaredDependency>com.fasterxml.jackson.core:jackson-annotations:jar:2.6.0</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>com.google.guava:guava:jar:17.0</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:2.6</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.python:jython-standalone:jar:2.7.0</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>commons-collections:commons-collections:jar:3.2.2</ignoredUsedUndeclaredDependency>
+
+                                    <ignoredUsedUndeclaredDependency>org.powermock:powermock-core:jar:1.6.5</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>commons-io:commons-io:jar:2.4</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.apache.commons:commons-collections4:jar:4.1</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.apache.commons:commons-lang3:jar:3.3.2</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.yaml:snakeyaml:jar:1.16</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>com.googlecode.lambdaj:lambdaj:jar:2.3.3</ignoredUsedUndeclaredDependency>
+                                    <ignoredUsedUndeclaredDependency>org.hamcrest:hamcrest-all:jar:1.3</ignoredUsedUndeclaredDependency>
+                                </ignoredUsedUndeclaredDependencies>
+
+                                <ignoredUnusedDeclaredDependencies combine.children="append">
+                                    <ignoredUnusedDeclaredDependency>io.cloudslang:score-all:jar:0.3.40</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>com.mattbertolini:liquibase-slf4j:jar:1.2.1</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>com.h2database:h2:jar:1.4.191</ignoredUnusedDeclaredDependency>
+
+                                    <ignoredUnusedDeclaredDependency>org.python:jython-standalone:jar:2.7.0</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>org.liquibase:liquibase-core:jar:3.4.2</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>2.8</version>
                     <executions>
                         <execution>
                             <id>analyze dependencies</id>


### PR DESCRIPTION
Fix for #890 
Introduce a mechanism to fail the build in case of undeclared dependencies which are used.
Also introduced a mechanism to fail the build in case of used but declared. This might produce several false positives so for now we will mostly investigate such findings adding them in the ignore list.

Signed-off-by: Lucian Musca <lucian-cristian.musca@hpe.com>