### PR TITLE
Adding logging service that handles logging requests on a dedicated thread

### DIFF
--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
@@ -182,8 +182,6 @@ public class SlangBuildMain {
 
         log.info(NEW_LINE + "Loading...");
 
-        //load application context
-//        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/testRunnerContext.xml");
         ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/testRunnerContext.xml");
         context.registerShutdownHook();
         SlangBuilder slangBuilder = context.getBean(SlangBuilder.class);

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
@@ -15,6 +15,8 @@ import io.cloudslang.lang.api.Slang;
 import io.cloudslang.lang.commons.services.api.UserConfigurationService;
 import io.cloudslang.lang.commons.services.impl.UserConfigurationServiceImpl;
 import io.cloudslang.lang.tools.build.commands.ApplicationArgs;
+import io.cloudslang.lang.tools.build.logging.LoggingService;
+import io.cloudslang.lang.tools.build.logging.LoggingServiceImpl;
 import io.cloudslang.lang.tools.build.tester.IRunTestResults;
 import io.cloudslang.lang.tools.build.tester.TestRun;
 import io.cloudslang.lang.tools.build.tester.parallel.report.SlangTestCaseRunReportGeneratorService;
@@ -34,6 +36,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -181,8 +184,11 @@ public class SlangBuildMain {
         log.info(NEW_LINE + "Loading...");
 
         //load application context
-        ApplicationContext context = new ClassPathXmlApplicationContext("spring/testRunnerContext.xml");
+//        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/testRunnerContext.xml");
+        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("spring/testRunnerContext.xml");
+        context.registerShutdownHook();
         SlangBuilder slangBuilder = context.getBean(SlangBuilder.class);
+        LoggingService loggingService = context.getBean(LoggingServiceImpl.class);
         Slang slang = context.getBean(Slang.class);
 
         updateTestSuiteMappings(context.getBean(TestRunInfoService.class), testSuitesParallel, testSuitesSequential, testSuites, unspecifiedTestSuiteRunMode);
@@ -195,24 +201,26 @@ public class SlangBuildMain {
                     testSuites, shouldValidateDescription, bulkRunMode);
             exceptions.addAll(buildResults.getCompilationExceptions());
             if (exceptions.size() > 0) {
-                logErrors(exceptions, projectPath);
+                logErrors(exceptions, projectPath, loggingService);
             }
             IRunTestResults runTestsResults = buildResults.getRunTestsResults();
             Map<String, TestRun> skippedTests = runTestsResults.getSkippedTests();
 
+
             if (isNotEmpty(skippedTests)) {
-                printSkippedTestsSummary(skippedTests);
+                printSkippedTestsSummary(skippedTests, loggingService);
             }
-            printPassedTests(runTestsResults);
+            printPassedTests(runTestsResults, loggingService);
             if (shouldPrintCoverageData) {
-                printTestCoverageData(runTestsResults);
+                printTestCoverageData(runTestsResults, loggingService);
             }
 
             if (isNotEmpty(runTestsResults.getFailedTests())) {
-                printBuildFailureSummary(projectPath, runTestsResults);
+                printBuildFailureSummary(projectPath, runTestsResults, loggingService);
             } else {
-                printBuildSuccessSummary(contentPath, buildResults, runTestsResults);
+                printBuildSuccessSummary(contentPath, buildResults, runTestsResults, loggingService);
             }
+            loggingService.waitForAllLogTasks();
 
             generateTestCaseReport(
                     context.getBean(SlangTestCaseRunReportGeneratorService.class),
@@ -222,9 +230,9 @@ public class SlangBuildMain {
             System.exit(isNotEmpty(runTestsResults.getFailedTests()) ? 1 : 0);
 
         } catch (Throwable e) {
-            logErrorsPrefix();
+            logErrorsPrefix(loggingService);
             log.error("Exception: " + e.getMessage());
-            logErrorsSuffix(projectPath);
+            logErrorsSuffix(projectPath, loggingService);
             System.exit(1);
         }
     }
@@ -335,25 +343,25 @@ public class SlangBuildMain {
         return ArgumentProcessorUtils.parseTestSuitesToList(valueList);
     }
 
-    private static void logErrors(List<RuntimeException> exceptions, String projectPath) {
-        logErrorsPrefix();
+    private static void logErrors(List<RuntimeException> exceptions, String projectPath, final LoggingService loggingService) {
+        logErrorsPrefix(loggingService);
         for (RuntimeException runtimeException : exceptions) {
-            log.error("Exception: " + runtimeException.getMessage());
+            loggingService.logEvent(Level.ERROR, "Exception: " + runtimeException.getMessage());
         }
-        logErrorsSuffix(projectPath);
+        logErrorsSuffix(projectPath, loggingService);
         System.exit(1);
     }
 
-    private static void logErrorsSuffix(String projectPath) {
-        log.error("FAILURE: Validation of slang files for project: \""
+    private static void logErrorsSuffix(String projectPath, final LoggingService loggingService) {
+        loggingService.logEvent(Level.ERROR, "FAILURE: Validation of slang files for project: \""
                 + projectPath + "\" failed.");
-        log.error("------------------------------------------------------------");
-        log.error("");
+        loggingService.logEvent(Level.ERROR, "------------------------------------------------------------");
+        loggingService.logEvent(Level.ERROR, "");
     }
 
-    private static void logErrorsPrefix() {
-        log.error("");
-        log.error("------------------------------------------------------------");
+    private static void logErrorsPrefix(final LoggingService loggingService) {
+        loggingService.logEvent(Level.ERROR, "");
+        loggingService.logEvent(Level.ERROR, "------------------------------------------------------------");
     }
 
     private static void generateTestCaseReport(
@@ -427,89 +435,89 @@ public class SlangBuildMain {
         }
     }
 
-    private static void printBuildSuccessSummary(String contentPath, SlangBuildResults buildResults, IRunTestResults runTestsResults) {
-        log.info("");
-        log.info("------------------------------------------------------------");
-        log.info("BUILD SUCCESS");
-        log.info("------------------------------------------------------------");
-        log.info("Found " + buildResults.getNumberOfCompiledSources()
+    private static void printBuildSuccessSummary(String contentPath, SlangBuildResults buildResults, IRunTestResults runTestsResults, final LoggingService loggingService) {
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
+        loggingService.logEvent(Level.INFO, "BUILD SUCCESS");
+        loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
+        loggingService.logEvent(Level.INFO, "Found " + buildResults.getNumberOfCompiledSources()
                 + " slang files under directory: \"" + contentPath + "\" and all are valid.");
-        printNumberOfPassedAndSkippedTests(runTestsResults);
-        log.info("");
+        printNumberOfPassedAndSkippedTests(runTestsResults, loggingService);
+        loggingService.logEvent(Level.INFO, "");
     }
 
-    private static void printNumberOfPassedAndSkippedTests(IRunTestResults runTestsResults) {
-        log.info(runTestsResults.getPassedTests().size() + " test cases passed");
+    private static void printNumberOfPassedAndSkippedTests(IRunTestResults runTestsResults, final LoggingService loggingService) {
+        loggingService.logEvent(Level.INFO, runTestsResults.getPassedTests().size() + " test cases passed");
         Map<String, TestRun> skippedTests = runTestsResults.getSkippedTests();
         if (skippedTests.size() > 0) {
-            log.info(skippedTests.size() + " test cases skipped");
+            loggingService.logEvent(Level.INFO, skippedTests.size() + " test cases skipped");
         }
     }
 
-    private static void printPassedTests(IRunTestResults runTestsResults) {
+    private static void printPassedTests(IRunTestResults runTestsResults, final LoggingService loggingService) {
         if (runTestsResults.getPassedTests().size() > 0) {
-            log.info("------------------------------------------------------------");
-            log.info("Following " + runTestsResults.getPassedTests().size() + " test cases passed:");
+            loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
+            loggingService.logEvent(Level.INFO, "Following " + runTestsResults.getPassedTests().size() + " test cases passed:");
             for (Map.Entry<String, TestRun> passedTest : runTestsResults.getPassedTests().entrySet()) {
                 String testCaseReference = SlangTestCase.generateTestCaseReference(passedTest.getValue().getTestCase());
-                log.info("- " + testCaseReference.replaceAll("\n", "\n\t"));
+                loggingService.logEvent(Level.INFO, "- " + testCaseReference.replaceAll("\n", "\n\t"));
             }
         }
     }
 
-    private static void printBuildFailureSummary(String projectPath, IRunTestResults runTestsResults) {
-        printNumberOfPassedAndSkippedTests(runTestsResults);
+    private static void printBuildFailureSummary(String projectPath, IRunTestResults runTestsResults, final LoggingService loggingService) {
+        printNumberOfPassedAndSkippedTests(runTestsResults, loggingService);
         Map<String, TestRun> failedTests = runTestsResults.getFailedTests();
-        logErrorsPrefix();
-        log.error("BUILD FAILURE");
-        log.error("------------------------------------------------------------");
-        log.error("CloudSlang build for repository: \"" + projectPath + "\" failed due to failed tests.");
-        log.error("Following " + failedTests.size() + " tests failed:");
+        logErrorsPrefix(loggingService);
+        loggingService.logEvent(Level.ERROR, "BUILD FAILURE");
+        loggingService.logEvent(Level.ERROR, "------------------------------------------------------------");
+        loggingService.logEvent(Level.ERROR, "CloudSlang build for repository: \"" + projectPath + "\" failed due to failed tests.");
+        loggingService.logEvent(Level.ERROR, "Following " + failedTests.size() + " tests failed:");
         for (Map.Entry<String, TestRun> failedTest : failedTests.entrySet()) {
             String failureMessage = failedTest.getValue().getMessage();
-            log.error("- " + failureMessage.replaceAll("\n", "\n\t"));
+            loggingService.logEvent(Level.ERROR, "- " + failureMessage.replaceAll("\n", "\n\t"));
         }
-        log.error("");
+        loggingService.logEvent(Level.ERROR, "");
     }
 
-    private static void printSkippedTestsSummary(Map<String, TestRun> skippedTests) {
-        log.info("");
-        log.info("------------------------------------------------------------");
-        log.info("Following " + skippedTests.size() + " tests were skipped:");
+    private static void printSkippedTestsSummary(Map<String, TestRun> skippedTests, final LoggingService loggingService) {
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
+        loggingService.logEvent(Level.INFO, "Following " + skippedTests.size() + " tests were skipped:");
         for (Map.Entry<String, TestRun> skippedTest : skippedTests.entrySet()) {
             String message = skippedTest.getValue().getMessage();
-            log.info("- " + message.replaceAll("\n", "\n\t"));
+            loggingService.logEvent(Level.INFO, "- " + message.replaceAll("\n", "\n\t"));
         }
     }
 
-    private static void printTestCoverageData(IRunTestResults runTestsResults) {
-        printCoveredExecutables(runTestsResults.getCoveredExecutables());
-        printUncoveredExecutables(runTestsResults.getUncoveredExecutables());
+    private static void printTestCoverageData(IRunTestResults runTestsResults, final LoggingService loggingService) {
+        printCoveredExecutables(runTestsResults.getCoveredExecutables(), loggingService);
+        printUncoveredExecutables(runTestsResults.getUncoveredExecutables(), loggingService);
         int coveredExecutablesSize = runTestsResults.getCoveredExecutables().size();
         int uncoveredExecutablesSize = runTestsResults.getUncoveredExecutables().size();
         int totalNumberOfExecutables = coveredExecutablesSize + uncoveredExecutablesSize;
         double coveragePercentage = (double) coveredExecutablesSize / (double) totalNumberOfExecutables * 100;
-        log.info("");
-        log.info("------------------------------------------------------------");
-        log.info(((int) coveragePercentage) + "% of the content has tests");
-        log.info("Out of " + totalNumberOfExecutables + " executables, " + coveredExecutablesSize + " executables have tests");
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
+        loggingService.logEvent(Level.INFO, ((int) coveragePercentage) + "% of the content has tests");
+        loggingService.logEvent(Level.INFO, "Out of " + totalNumberOfExecutables + " executables, " + coveredExecutablesSize + " executables have tests");
     }
 
-    private static void printCoveredExecutables(Set<String> coveredExecutables) {
-        log.info("");
-        log.info("------------------------------------------------------------");
-        log.info("Following " + coveredExecutables.size() + " executables have tests:");
+    private static void printCoveredExecutables(Set<String> coveredExecutables, final LoggingService loggingService) {
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
+        loggingService.logEvent(Level.INFO, "Following " + coveredExecutables.size() + " executables have tests:");
         for (String executable : coveredExecutables) {
-            log.info("- " + executable);
+            loggingService.logEvent(Level.INFO, "- " + executable);
         }
     }
 
-    private static void printUncoveredExecutables(Set<String> uncoveredExecutables) {
-        log.info("");
-        log.info("------------------------------------------------------------");
-        log.info("Following " + uncoveredExecutables.size() + " executables do not have tests:");
+    private static void printUncoveredExecutables(Set<String> uncoveredExecutables, final LoggingService loggingService) {
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
+        loggingService.logEvent(Level.INFO, "Following " + uncoveredExecutables.size() + " executables do not have tests:");
         for (String executable : uncoveredExecutables) {
-            log.info("- " + executable);
+            loggingService.logEvent(Level.INFO, "- " + executable);
         }
     }
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildMain.java
@@ -38,7 +38,6 @@ import org.apache.commons.lang.Validate;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static io.cloudslang.lang.tools.build.ArgumentProcessorUtils.getBooleanFromPropertiesWithDefault;
@@ -220,7 +219,7 @@ public class SlangBuildMain {
             } else {
                 printBuildSuccessSummary(contentPath, buildResults, runTestsResults, loggingService);
             }
-            loggingService.waitForAllLogTasks();
+            loggingService.waitForAllLogTasksToFinish();
 
             generateTestCaseReport(
                     context.getBean(SlangTestCaseRunReportGeneratorService.class),

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuilder.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuilder.java
@@ -12,6 +12,7 @@ package io.cloudslang.lang.tools.build;
 import io.cloudslang.lang.compiler.modeller.model.Executable;
 import io.cloudslang.lang.entities.CompilationArtifact;
 import io.cloudslang.lang.tools.build.SlangBuildMain.BulkRunMode;
+import io.cloudslang.lang.tools.build.logging.LoggingService;
 import io.cloudslang.lang.tools.build.tester.IRunTestResults;
 import io.cloudslang.lang.tools.build.tester.RunTestsResults;
 import io.cloudslang.lang.tools.build.tester.SlangTestRunner;
@@ -30,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -56,18 +58,19 @@ public class SlangBuilder {
     @Autowired
     private SlangTestRunner slangTestRunner;
 
-    private final static Logger log = Logger.getLogger(SlangBuilder.class);
+    @Autowired
+    private LoggingService loggingService;
 
     public SlangBuildResults buildSlangContent(String projectPath, String contentPath, String testsPath, List<String> testSuits, boolean shouldValidateDescription, BulkRunMode bulkRunMode) {
 
         String projectName = FilenameUtils.getName(projectPath);
-        log.info("");
-        log.info("------------------------------------------------------------");
-        log.info("Building project: " + projectName);
-        log.info("------------------------------------------------------------");
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
+        loggingService.logEvent(Level.INFO, "Building project: " + projectName);
+        loggingService.logEvent(Level.INFO, "------------------------------------------------------------");
 
-        log.info("");
-        log.info("--- compiling sources ---");
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "--- compiling sources ---");
         CompilationResult compilationResult =
                 slangContentVerifier.createModelsAndValidate(contentPath, shouldValidateDescription);
         Map<String, Executable> slangModels = compilationResult.getResults();
@@ -99,14 +102,14 @@ public class SlangBuilder {
                     + compiledSlangFiles.size());
         }
 
-        log.info("Successfully finished Compilation of: " + compiledSlangFiles.size() + " Slang files");
+        loggingService.logEvent(Level.INFO, "Successfully finished Compilation of: " + compiledSlangFiles.size() + " Slang files");
         return compiledSlangFiles;
     }
 
     IRunTestResults runTests(Map<String, Executable> contentSlangModels,
                              String projectPath, String testsPath, List<String> testSuites, BulkRunMode bulkRunMode) {
-        log.info("");
-        log.info("--- compiling tests sources ---");
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "--- compiling tests sources ---");
         // Compile all slang test flows under the test directory
         CompilationResult compilationResult = slangContentVerifier.createModelsAndValidate(testsPath, false);
         Map<String, Executable> testFlowModels = compilationResult.getResults();
@@ -119,9 +122,9 @@ public class SlangBuilder {
 
         Set<String> allTestedFlowsFQN = mapExecutablesToFullyQualifiedName(allTestedFlowModels.values());
         Map<String, SlangTestCase> testCases = slangTestRunner.createTestCases(testsPath, allTestedFlowsFQN);
-        log.info("");
-        log.info("--- running tests ---");
-        log.info("Found " + testCases.size() + " tests");
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "--- running tests ---");
+        loggingService.logEvent(Level.INFO, "Found " + testCases.size() + " tests");
         IRunTestResults runTestsResults;
 
         runTestsResults = processRunTests(projectPath, testSuites, bulkRunMode, compiledFlows, testCases);

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuilder.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuilder.java
@@ -21,6 +21,12 @@ import io.cloudslang.lang.tools.build.tester.parallel.report.ThreadSafeRunTestRe
 import io.cloudslang.lang.tools.build.tester.parse.SlangTestCase;
 import io.cloudslang.lang.tools.build.verifier.CompilationResult;
 import io.cloudslang.lang.tools.build.verifier.SlangContentVerifier;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Level;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,12 +35,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import static io.cloudslang.lang.tools.build.SlangBuildMain.BulkRunMode.ALL_PARALLEL;
 import static io.cloudslang.lang.tools.build.SlangBuildMain.BulkRunMode.ALL_SEQUENTIAL;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/configuration/SlangBuildSpringConfiguration.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/configuration/SlangBuildSpringConfiguration.java
@@ -13,6 +13,7 @@ import io.cloudslang.lang.commons.configuration.SlangCommonsSpringConfig;
 import io.cloudslang.lang.tools.build.SlangBuilder;
 import io.cloudslang.lang.tools.build.logging.LoggingServiceImpl;
 import io.cloudslang.lang.tools.build.tester.SlangTestRunner;
+import io.cloudslang.lang.tools.build.tester.parallel.report.LoggingSlangTestCaseEventListener;
 import io.cloudslang.lang.tools.build.tester.parallel.report.SlangTestCaseRunReportGeneratorService;
 import io.cloudslang.lang.tools.build.tester.parallel.services.ParallelTestCaseExecutorService;
 import io.cloudslang.lang.tools.build.tester.parallel.services.TestCaseEventDispatchService;
@@ -77,6 +78,11 @@ public class SlangBuildSpringConfiguration {
     @Bean
     public LoggingServiceImpl loggingService() {
         return new LoggingServiceImpl();
+    }
+
+    @Bean
+    public LoggingSlangTestCaseEventListener loggingSlangTestCaseEventListener() {
+        return new LoggingSlangTestCaseEventListener();
     }
 
 }

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/configuration/SlangBuildSpringConfiguration.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/configuration/SlangBuildSpringConfiguration.java
@@ -11,6 +11,7 @@ package io.cloudslang.lang.tools.build.configuration;
 
 import io.cloudslang.lang.commons.configuration.SlangCommonsSpringConfig;
 import io.cloudslang.lang.tools.build.SlangBuilder;
+import io.cloudslang.lang.tools.build.logging.LoggingServiceImpl;
 import io.cloudslang.lang.tools.build.tester.SlangTestRunner;
 import io.cloudslang.lang.tools.build.tester.parallel.report.SlangTestCaseRunReportGeneratorService;
 import io.cloudslang.lang.tools.build.tester.parallel.services.ParallelTestCaseExecutorService;
@@ -71,6 +72,11 @@ public class SlangBuildSpringConfiguration {
     @Bean
     public TestRunInfoServiceImpl runConfigurationService() {
         return new TestRunInfoServiceImpl();
+    }
+
+    @Bean
+    public LoggingServiceImpl loggingService() {
+        return new LoggingServiceImpl();
     }
 
 }

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
@@ -18,5 +18,5 @@ public interface LoggingService {
 
     Future<?> logEvent(final Level level, final String message);
     Future<?> logEvent(final Level level, final String message, final Throwable throwable);
-
+    void waitForAllLogTasks();
 }

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
@@ -1,0 +1,13 @@
+package io.cloudslang.lang.tools.build.logging;
+
+
+import org.apache.log4j.Level;
+
+import java.util.concurrent.Future;
+
+public interface LoggingService {
+
+    Future<?> logEvent(final Level level, final String message);
+    Future<?> logEvent(final Level level, final String message, final Throwable throwable);
+
+}

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
@@ -17,6 +17,8 @@ import java.util.concurrent.Future;
 public interface LoggingService {
 
     Future<?> logEvent(final Level level, final String message);
+
     Future<?> logEvent(final Level level, final String message, final Throwable throwable);
+
     void waitForAllLogTasksToFinish();
 }

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
@@ -18,5 +18,5 @@ public interface LoggingService {
 
     Future<?> logEvent(final Level level, final String message);
     Future<?> logEvent(final Level level, final String message, final Throwable throwable);
-    void waitForAllLogTasks();
+    void waitForAllLogTasksToFinish();
 }

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingService.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.logging;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImpl.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImpl.java
@@ -159,18 +159,4 @@ public class LoggingServiceImpl implements LoggingService, DisposableBean {
         }
     }
 
-//    public static void main(String[] args) throws Exception {
-//        LoggingServiceImpl loggingService = new LoggingServiceImpl();
-//        loggingService.initialize();
-//        Future<?> future1 = loggingService.logEvent(DEBUG, "Ana are mere");
-//        Future<?> future2 = loggingService.logEvent(INFO, "We are what we are");
-//        Future<?> future3 = loggingService.logEvent(ERROR, "Bianca are mere", new RuntimeException("BIANCA!"));
-//
-////        future1.get();
-////        future2.get();
-////        future3.get();
-//        loggingService.destroy();
-//    }
-
-
 }

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImpl.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.logging;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImpl.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImpl.java
@@ -1,0 +1,176 @@
+package io.cloudslang.lang.tools.build.logging;
+
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.DisposableBean;
+
+import javax.annotation.PostConstruct;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.apache.log4j.Level.DEBUG;
+import static org.apache.log4j.Level.ERROR;
+import static org.apache.log4j.Level.FATAL;
+import static org.apache.log4j.Level.INFO;
+import static org.apache.log4j.Level.TRACE;
+import static org.apache.log4j.Level.WARN;
+
+/**
+ * Implements a logging service that is asynchronous with respect to the caller
+ */
+public class LoggingServiceImpl implements LoggingService, DisposableBean {
+    private static final Logger logger = Logger.getLogger(LoggingServiceImpl.class);
+
+    private ExecutorService singleThreadExecutor;
+
+    @PostConstruct
+    public void initialize() {
+        singleThreadExecutor = newFixedThreadPool(1);
+    }
+
+    @Override
+    public Future<?> logEvent(Level level, String message) {
+        return doLogEvent(level, message, null);
+    }
+
+    @Override
+    public Future<?> logEvent(Level level, String message, Throwable throwable) {
+        return doLogEvent(level, message, throwable);
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        singleThreadExecutor.shutdown();
+        singleThreadExecutor = null;
+    }
+
+    private Future<?> doLogEvent(Level level, String message, Throwable throwable) {
+        try {
+            return doSubmit(level, message, throwable);
+        } catch (RejectedExecutionException rejectedExecutionException) {
+            try {
+                return doSubmit(level, message, throwable);
+            } catch (RejectedExecutionException rejectedExecutionException2) {
+                // try twice and fail
+            }
+        }
+        return null;
+    }
+
+    private Future<?> doSubmit(Level level, String message, Throwable throwable) {
+        return singleThreadExecutor.submit((throwable != null) ? new LoggingDetailsRunnable(level, message, throwable)
+                : new LoggingDetailsRunnable(level, message));
+    }
+
+    static class LoggingDetailsRunnable implements Runnable {
+        private final Level level;
+        private final String message;
+        private final Throwable exception;
+
+        LoggingDetailsRunnable(Level level, String message, Throwable t) {
+            this.level = level;
+            this.message = message;
+            this.exception = t;
+        }
+
+        LoggingDetailsRunnable(Level level, String message) {
+            this(level, message, null);
+        }
+
+        @Override
+        public void run() {
+            try {
+                String localMessage = StringUtils.isEmpty(message) ? "" : message;
+                final Throwable throwable = exception;
+                if (exception == null) {
+                    if (level == TRACE) {
+                        if (logger.isTraceEnabled()) {
+                            logger.trace(localMessage);
+                        }
+                    } else if (level == DEBUG) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(localMessage);
+                        }
+                    } else if (level == INFO) {
+                        logger.info(localMessage);
+                    } else if (level == WARN) {
+                        logger.warn(localMessage);
+                    } else if (level == ERROR) {
+                        logger.error(localMessage);
+                    } else if (level == FATAL) {
+                        logger.fatal(localMessage);
+                    }
+                } else {
+                    if (level == TRACE) {
+                        if (logger.isTraceEnabled()) {
+                            logger.trace(localMessage, throwable);
+                        }
+                    } else if (level == DEBUG) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(localMessage, throwable);
+                        }
+                    } else if (level == INFO) {
+                        logger.info(localMessage, throwable);
+                    } else if (level == WARN) {
+                        logger.warn(localMessage, throwable);
+                    } else if (level == ERROR) {
+                        logger.error(localMessage, throwable);
+                    } else if (level == FATAL) {
+                        logger.fatal(localMessage, throwable);
+                    }
+                }
+            } catch (Exception ignore) {
+                // so that this thread does not die
+            }
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (obj == this) {
+                return true;
+            }
+            if (obj.getClass() != getClass()) {
+                return false;
+            }
+            LoggingDetailsRunnable rhs = (LoggingDetailsRunnable) obj;
+            return new EqualsBuilder()
+                    .append(this.level, rhs.level)
+                    .append(this.message, rhs.message)
+                    .append(this.exception, rhs.exception)
+                    .isEquals();
+        }
+
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder()
+                    .append(level)
+                    .append(message)
+                    .append(exception)
+                    .toHashCode();
+        }
+    }
+
+//    public static void main(String[] args) throws Exception {
+//        LoggingServiceImpl loggingService = new LoggingServiceImpl();
+//        loggingService.initialize();
+//        Future<?> future1 = loggingService.logEvent(DEBUG, "Ana are mere");
+//        Future<?> future2 = loggingService.logEvent(INFO, "We are what we are");
+//        Future<?> future3 = loggingService.logEvent(ERROR, "Bianca are mere", new RuntimeException("BIANCA!"));
+//
+////        future1.get();
+////        future2.get();
+////        future3.get();
+//        loggingService.destroy();
+//    }
+
+
+}

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
@@ -86,6 +86,9 @@ public class SlangTestRunner {
     @Autowired
     private LoggingService loggingService;
 
+    @Autowired
+    private LoggingSlangTestCaseEventListener loggingSlangTestCaseEventListener;
+
     private String[] TEST_CASE_FILE_EXTENSIONS = {"yaml", "yml"};
     private static final String TEST_CASE_PASSED = "Test case passed: ";
     private static final String TEST_CASE_FAILED = "Test case failed: ";
@@ -181,7 +184,7 @@ public class SlangTestRunner {
 
         testCaseEventDispatchService.unregisterAllListeners();
         testCaseEventDispatchService.registerListener(runTestsResults); // for gathering of report data
-        testCaseEventDispatchService.registerListener(new LoggingSlangTestCaseEventListener()); // for logging purpose
+        testCaseEventDispatchService.registerListener(loggingSlangTestCaseEventListener); // for logging purpose
 
         MultiTriggerTestCaseEventListener multiTriggerTestCaseEventListener = new MultiTriggerTestCaseEventListener();
         slang.subscribeOnEvents(multiTriggerTestCaseEventListener, createListenerEventTypesSet());

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
@@ -18,6 +18,7 @@ import io.cloudslang.lang.entities.bindings.values.Value;
 import io.cloudslang.lang.tools.build.SlangBuildMain;
 import io.cloudslang.lang.tools.build.SlangBuildMain.BulkRunMode;
 import io.cloudslang.lang.tools.build.SlangBuildMain.TestCaseRunMode;
+import io.cloudslang.lang.tools.build.logging.LoggingService;
 import io.cloudslang.lang.tools.build.tester.parallel.MultiTriggerTestCaseEventListener;
 import io.cloudslang.lang.tools.build.tester.parallel.report.LoggingSlangTestCaseEventListener;
 import io.cloudslang.lang.tools.build.tester.parallel.report.ThreadSafeRunTestResults;
@@ -30,6 +31,16 @@ import io.cloudslang.lang.tools.build.tester.runconfiguration.TestRunInfoService
 import io.cloudslang.lang.tools.build.tester.runconfiguration.strategy.RunMultipleTestSuiteConflictResolutionStrategy;
 import io.cloudslang.lang.tools.build.tester.runconfiguration.strategy.SequentialRunTestSuiteResolutionStrategy;
 import io.cloudslang.score.events.EventConstants;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.log4j.Level;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
@@ -42,15 +53,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
-import org.apache.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import static java.lang.Long.parseLong;
 import static java.lang.String.valueOf;
@@ -81,11 +83,13 @@ public class SlangTestRunner {
     @Autowired
     private TestRunInfoService testRunInfoService;
 
+    @Autowired
+    private LoggingService loggingService;
+
     private String[] TEST_CASE_FILE_EXTENSIONS = {"yaml", "yml"};
     private static final String TEST_CASE_PASSED = "Test case passed: ";
     private static final String TEST_CASE_FAILED = "Test case failed: ";
 
-    private static final Logger log = Logger.getLogger(SlangTestRunner.class);
     private static final String UNAVAILABLE_NAME = "N/A";
 
     public enum TestCaseRunState {
@@ -101,10 +105,10 @@ public class SlangTestRunner {
                 "Directory path argument \'" + testPath + "\' does not lead to a directory");
         Collection<File> testCasesFiles = FileUtils.listFiles(testPathDir, TEST_CASE_FILE_EXTENSIONS, true);
 
-        log.info("");
-        log.info("--- parsing test cases ---");
-        log.info("Start parsing all test cases files under: " + testPath);
-        log.info(testCasesFiles.size() + " test cases files were found");
+        loggingService.logEvent(Level.INFO, "");
+        loggingService.logEvent(Level.INFO, "--- parsing test cases ---");
+        loggingService.logEvent(Level.INFO, "Start parsing all test cases files under: " + testPath);
+        loggingService.logEvent(Level.INFO, testCasesFiles.size() + " test cases files were found");
 
         Map<String, SlangTestCase> testCases = new HashMap<>();
         Set<SlangTestCase> testCasesWithMissingReference = new HashSet<>();
@@ -157,7 +161,7 @@ public class SlangTestRunner {
         for (Map.Entry<String, SlangTestCase> testCaseEntry : testCases.entrySet()) {
             SlangTestCase testCase = testCaseEntry.getValue();
 
-            log.info("Running test: " + SlangTestCase.generateTestCaseReference(testCase) + " - " + testCase.getDescription());
+            loggingService.logEvent(Level.INFO, "Running test: " + SlangTestCase.generateTestCaseReference(testCase) + " - " + testCase.getDescription());
             try {
                 CompilationArtifact compiledTestFlow = getCompiledTestFlow(compiledFlows, testCase);
                 runTest(testCase, compiledTestFlow, projectPath);
@@ -196,7 +200,7 @@ public class SlangTestRunner {
                 try {
                     testCaseFuture.get(testCaseTimeoutMinutes, MINUTES);
                 } catch (InterruptedException e) {
-                    log.error("Interrupted while waiting for result: ", e);
+                    loggingService.logEvent(Level.ERROR, "Interrupted while waiting for result: ", e);
                 } catch (TimeoutException e) {
                     testCaseEventDispatchService.notifyListeners(new FailedSlangTestCaseEvent(testCase, "Timeout reached for test case " + testCase.getName(), e));
                 } catch (Exception e) {
@@ -211,10 +215,10 @@ public class SlangTestRunner {
 
     private void printTestForActualRunSummary(TestCaseRunMode runMode, Map<String, SlangTestCase> testCases) {
         if (!MapUtils.isEmpty(testCases)) {
-            log.info("Running " + testCases.size() + " test(s) in " + runMode.toString().toLowerCase(Locale.ENGLISH) + ": ");
+            loggingService.logEvent(Level.INFO, "Running " + testCases.size() + " test(s) in " + runMode.toString().toLowerCase(Locale.ENGLISH) + ": ");
             for (Map.Entry<String, SlangTestCase> stringSlangTestCaseEntry : testCases.entrySet()) {
                 final SlangTestCase slangTestCase = stringSlangTestCaseEntry.getValue();
-                log.info(PREFIX_DASH + SlangTestCase.generateTestCaseReference(slangTestCase));
+                loggingService.logEvent(Level.INFO, PREFIX_DASH + SlangTestCase.generateTestCaseReference(slangTestCase));
             }
         }
     }
@@ -275,7 +279,7 @@ public class SlangTestRunner {
     private void processSkippedTest(final IRunTestResults runTestsResults, Map.Entry<String, SlangTestCase> testCaseEntry, SlangTestCase testCase,
                                     final Map<TestCaseRunState, Map<String, SlangTestCase>> resultMap) {
         String message = "Skipping test: " + SlangTestCase.generateTestCaseReference(testCase) + " because it is not in active test suites";
-        log.info(message);
+        loggingService.logEvent(Level.INFO, message);
 
         runTestsResults.addSkippedTest(testCase.getName(), new TestRun(testCase, message));
         resultMap.get(TestCaseRunState.INACTIVE).put(testCaseEntry.getKey(), testCaseEntry.getValue());
@@ -285,7 +289,7 @@ public class SlangTestRunner {
         try {
             return parseLong(getProperty(TEST_CASE_TIMEOUT_IN_MINUTES_KEY, valueOf(MAX_TIME_PER_TESTCASE_IN_MINUTES)));
         } catch (NumberFormatException nfEx) {
-            log.warn(String.format("Misconfigured test case timeout '%s'. Using default timeout %d.", getProperty(TEST_CASE_TIMEOUT_IN_MINUTES_KEY), MAX_TIME_PER_TESTCASE_IN_MINUTES));
+            loggingService.logEvent(Level.WARN, String.format("Misconfigured test case timeout '%s'. Using default timeout %d.", getProperty(TEST_CASE_TIMEOUT_IN_MINUTES_KEY), MAX_TIME_PER_TESTCASE_IN_MINUTES));
             return MAX_TIME_PER_TESTCASE_IN_MINUTES;
         }
     }
@@ -298,10 +302,10 @@ public class SlangTestRunner {
     private void printTestCasesWithMissingReference(Set<SlangTestCase> testCasesWithMissingReference) {
         int testCasesWithMissingReferenceSize = testCasesWithMissingReference.size();
         if (testCasesWithMissingReferenceSize > 0) {
-            log.info("");
-            log.info(testCasesWithMissingReferenceSize + " test cases have missing test flow references:");
+            loggingService.logEvent(Level.INFO, "");
+            loggingService.logEvent(Level.INFO, testCasesWithMissingReferenceSize + " test cases have missing test flow references:");
             for (SlangTestCase slangTestCase : testCasesWithMissingReference) {
-                log.info(
+                loggingService.logEvent(Level.INFO,
                         "For test case: " + SlangTestCase.generateTestCaseReference(slangTestCase) +
                                 " testFlowPath reference not found: " +
                                 slangTestCase.getTestFlowPath()
@@ -409,21 +413,21 @@ public class SlangTestRunner {
         if (StringUtils.isNotBlank(errorMessageFlowExecution)) {
             // unexpected exception occurred during flow execution
             message = "Error occurred while running test: " + testCaseReference + " - " + testCase.getDescription() + "\n\t" + errorMessageFlowExecution;
-            log.info(message);
+            loggingService.logEvent(Level.INFO, message);
             throw new RuntimeException(message);
         }
 
         String executionResult = testsEventListener.getResult();
         if (result != null && !result.equals(executionResult)) {
             message = TEST_CASE_FAILED + testCaseReference + " - " + testCase.getDescription() + "\n\tExpected result: " + result + "\n\tActual result: " + executionResult;
-            log.error(message);
+            loggingService.logEvent(Level.ERROR, message);
             throw new RuntimeException(message);
         }
 
         Map<String, Serializable> executionOutputs = testsEventListener.getOutputs();
         handleTestCaseFailuresFromOutputs(testCase, testCaseReference, outputs, executionOutputs);
 
-        log.info(TEST_CASE_PASSED + testCaseReference + ". Finished running: " + flowName + " with result: " + executionResult);
+        loggingService.logEvent(Level.INFO, TEST_CASE_PASSED + testCaseReference + ". Finished running: " + flowName + " with result: " + executionResult);
         return executionId;
     }
 
@@ -453,21 +457,21 @@ public class SlangTestRunner {
         if (StringUtils.isNotBlank(errorMessageFlowExecution)) {
             // unexpected exception occurred during flow execution
             message = "Error occurred while running test: " + testCaseReference + " - " + testCase.getDescription() + "\n\t" + errorMessageFlowExecution;
-            log.info(message);
+            loggingService.logEvent(Level.INFO, message);
             throw new RuntimeException(message);
         }
 
         String executionResult = globalListener.getResultByExecutionId(executionId);
         if (result != null && !result.equals(executionResult)) {
             message = TEST_CASE_FAILED + testCaseReference + " - " + testCase.getDescription() + "\n\tExpected result: " + result + "\n\tActual result: " + executionResult;
-            log.error(message);
+            loggingService.logEvent(Level.ERROR, message);
             throw new RuntimeException(message);
         }
 
         Map<String, Serializable> executionOutputs = globalListener.getOutputsByExecutionId(executionId);
         handleTestCaseFailuresFromOutputs(testCase, testCaseReference, outputs, executionOutputs);
 
-        log.info(TEST_CASE_PASSED + testCaseReference + ". Finished running: " + flowName + " with result: " + executionResult);
+        loggingService.logEvent(Level.INFO, TEST_CASE_PASSED + testCaseReference + ". Finished running: " + flowName + " with result: " + executionResult);
         return executionId;
     }
 
@@ -477,10 +481,10 @@ public class SlangTestRunner {
 
             message = TEST_CASE_FAILED + testCaseReference + " - " + testCase.getDescription() + "\n\tFlow " +
                     compilationArtifact.getExecutionPlan().getName() + " did not throw an exception as expected";
-            log.info(message);
+            loggingService.logEvent(Level.INFO, message);
             throw new RuntimeException(message);
         }
-        log.info(TEST_CASE_PASSED + testCaseReference + ". Finished running: " + flowName + " with exception as expected");
+        loggingService.logEvent(Level.INFO, TEST_CASE_PASSED + testCaseReference + ". Finished running: " + flowName + " with exception as expected");
         return executionId;
     }
 
@@ -501,7 +505,7 @@ public class SlangTestRunner {
                 if (!executionOutputs.containsKey(outputName) ||
                         !outputsAreEqual(outputValue, executionOutputValue)) {
                     message = TEST_CASE_FAILED + testCaseReference + " - " + testCase.getDescription() + "\n\tFor output: " + outputName + "\n\tExpected value: " + outputValue + "\n\tActual value: " + executionOutputValue;
-                    log.error(message);
+                    loggingService.logEvent(Level.ERROR, message);
                     throw new RuntimeException(message);
                 }
             }

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/report/LoggingSlangTestCaseEventListener.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/report/LoggingSlangTestCaseEventListener.java
@@ -1,24 +1,27 @@
 package io.cloudslang.lang.tools.build.tester.parallel.report;
 
 
+import io.cloudslang.lang.tools.build.logging.LoggingService;
 import io.cloudslang.lang.tools.build.tester.ISlangTestCaseEventListener;
 import io.cloudslang.lang.tools.build.tester.parallel.testcaseevents.BeginSlangTestCaseEvent;
 import io.cloudslang.lang.tools.build.tester.parallel.testcaseevents.SkippedSlangTestCaseEvent;
 import io.cloudslang.lang.tools.build.tester.parallel.testcaseevents.SlangTestCaseEvent;
 import io.cloudslang.lang.tools.build.tester.parse.SlangTestCase;
-import org.apache.log4j.Logger;
+import org.apache.log4j.Level;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class LoggingSlangTestCaseEventListener implements ISlangTestCaseEventListener {
 
-    private static Logger log = Logger.getLogger(LoggingSlangTestCaseEventListener.class);
+    @Autowired
+    private LoggingService loggingService;
 
     @Override
     public synchronized void onEvent(SlangTestCaseEvent event) {
         SlangTestCase slangTestCase = event.getSlangTestCase();
         if (event instanceof BeginSlangTestCaseEvent) {
-            log.info("Running test: " + SlangTestCase.generateTestCaseReference(slangTestCase) + " - " + slangTestCase.getDescription());
+            loggingService.logEvent(Level.INFO, "Running test: " + SlangTestCase.generateTestCaseReference(slangTestCase) + " - " + slangTestCase.getDescription());
         } else if (event instanceof SkippedSlangTestCaseEvent) {
-            log.info("Skipping test: " + SlangTestCase.generateTestCaseReference(slangTestCase) + " because it is not in active test suites");
+            loggingService.logEvent(Level.INFO, "Skipping test: " + SlangTestCase.generateTestCaseReference(slangTestCase) + " because it is not in active test suites");
         }
     }
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/verifier/SlangContentVerifier.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/verifier/SlangContentVerifier.java
@@ -20,21 +20,21 @@ import io.cloudslang.lang.entities.CompilationArtifact;
 import io.cloudslang.lang.tools.build.logging.LoggingService;
 import io.cloudslang.lang.tools.build.validation.MetadataMissingException;
 import io.cloudslang.lang.tools.build.validation.StaticValidator;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.Validate;
+import org.apache.log4j.Level;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import java.io.File;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.Queue;
-import java.util.ArrayDeque;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.Validate;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * Created by stoneo on 3/15/2015.

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/verifier/SlangContentVerifier.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/verifier/SlangContentVerifier.java
@@ -17,6 +17,7 @@ import io.cloudslang.lang.compiler.modeller.model.Executable;
 import io.cloudslang.lang.compiler.modeller.model.Metadata;
 import io.cloudslang.lang.compiler.scorecompiler.ScoreCompiler;
 import io.cloudslang.lang.entities.CompilationArtifact;
+import io.cloudslang.lang.tools.build.logging.LoggingService;
 import io.cloudslang.lang.tools.build.validation.MetadataMissingException;
 import io.cloudslang.lang.tools.build.validation.StaticValidator;
 import java.io.File;
@@ -30,6 +31,7 @@ import java.util.Queue;
 import java.util.ArrayDeque;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.Validate;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -39,8 +41,6 @@ import org.springframework.stereotype.Component;
  **/
 @Component
 public class SlangContentVerifier {
-
-    private final static Logger log = Logger.getLogger(SlangContentVerifier.class);
 
     @Autowired
     private SlangCompiler slangCompiler;
@@ -54,14 +54,17 @@ public class SlangContentVerifier {
     @Autowired
     private ScoreCompiler scoreCompiler;
 
+    @Autowired
+    private LoggingService loggingService;
+
     public CompilationResult createModelsAndValidate(String directoryPath, boolean shouldValidateDescription) {
         Validate.notEmpty(directoryPath, "You must specify a path");
         Validate.isTrue(new File(directoryPath).isDirectory(), "Directory path argument \'" + directoryPath + "\' does not lead to a directory");
         Map<String, Executable> slangModels = new HashMap<>();
         Collection<File> slangFiles = listSlangFiles(new File(directoryPath), true);
-        log.info("Start compiling all slang files under: " + directoryPath);
-        log.info(slangFiles.size() + " .sl files were found");
-        log.info("");
+        loggingService.logEvent(Level.INFO, "Start compiling all slang files under: " + directoryPath);
+        loggingService.logEvent(Level.INFO, slangFiles.size() + " .sl files were found");
+        loggingService.logEvent(Level.INFO, "");
         Queue<RuntimeException> exceptions = new ArrayDeque<>();
         for (File slangFile: slangFiles) {
             Executable sourceModel = null;
@@ -76,7 +79,7 @@ public class SlangContentVerifier {
                 }
             } catch (Exception e) {
                 String errorMessage = "Failed to extract metadata for file: \'" + slangFile.getAbsoluteFile() + "\'.\n" + e.getMessage();
-                log.error(errorMessage);
+                loggingService.logEvent(Level.ERROR, errorMessage);
                 exceptions.add(new RuntimeException(errorMessage, e));
                 if (e instanceof MetadataMissingException && sourceModel != null) {
                     slangModels.put(getUniqueName(sourceModel), sourceModel);
@@ -103,15 +106,15 @@ public class SlangContentVerifier {
                     Set<Executable> dependenciesModels = getModelDependenciesRecursively(slangModels, slangModel);
                     compiledSource = scoreCompiler.compile(slangModel, dependenciesModels);
                     if (compiledSource != null) {
-                        log.info("Compiled: \'" + slangModel.getNamespace() + "." + slangModel.getName() + "\' successfully");
+                        loggingService.logEvent(Level.INFO, "Compiled: \'" + slangModel.getNamespace() + "." + slangModel.getName() + "\' successfully");
                         compiledArtifacts.put(getUniqueName(slangModel), compiledSource);
                     } else {
-                        log.error("Failed to compile source: \'" + slangModel.getNamespace() + "." + slangModel.getName() + "\'");
+                        loggingService.logEvent(Level.ERROR, "Failed to compile source: \'" + slangModel.getNamespace() + "." + slangModel.getName() + "\'");
                     }
                 }
             } catch (Exception e) {
                 String errorMessage = "Failed compiling Slang source: \'" + slangModel.getNamespace() + "." + slangModel.getName() + "\'.\n" + e.getMessage();
-                log.error(errorMessage);
+                loggingService.logEvent(Level.ERROR, errorMessage);
                 throw new RuntimeException(errorMessage, e);
             }
         }

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/SlangBuilderTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/SlangBuilderTest.java
@@ -21,6 +21,8 @@ import io.cloudslang.lang.compiler.scorecompiler.ScoreCompiler;
 import io.cloudslang.lang.entities.CompilationArtifact;
 import io.cloudslang.lang.entities.bindings.Input;
 import io.cloudslang.lang.tools.build.SlangBuildMain.BulkRunMode;
+import io.cloudslang.lang.tools.build.logging.LoggingService;
+import io.cloudslang.lang.tools.build.logging.LoggingServiceImpl;
 import io.cloudslang.lang.tools.build.tester.IRunTestResults;
 import io.cloudslang.lang.tools.build.tester.RunTestsResults;
 import io.cloudslang.lang.tools.build.tester.SlangTestRunner;
@@ -140,6 +142,9 @@ public class SlangBuilderTest {
 
     @Autowired
     private TestRunInfoService testRunInfoService;
+
+    @Autowired
+    private LoggingService loggingService;
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -648,5 +653,11 @@ public class SlangBuilderTest {
         public TestRunInfoService test() {
             return spy(TestRunInfoServiceImpl.class);
         }
+
+        @Bean
+        public LoggingService loggingService() {
+            return new LoggingServiceImpl();
+        }
+
     }
 }

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/SlangBuilderTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/SlangBuilderTest.java
@@ -27,6 +27,7 @@ import io.cloudslang.lang.tools.build.tester.IRunTestResults;
 import io.cloudslang.lang.tools.build.tester.RunTestsResults;
 import io.cloudslang.lang.tools.build.tester.SlangTestRunner;
 import io.cloudslang.lang.tools.build.tester.TestRun;
+import io.cloudslang.lang.tools.build.tester.parallel.report.LoggingSlangTestCaseEventListener;
 import io.cloudslang.lang.tools.build.tester.parallel.report.ThreadSafeRunTestResults;
 import io.cloudslang.lang.tools.build.tester.parallel.services.ParallelTestCaseExecutorService;
 import io.cloudslang.lang.tools.build.tester.parallel.services.TestCaseEventDispatchService;
@@ -145,6 +146,9 @@ public class SlangBuilderTest {
 
     @Autowired
     private LoggingService loggingService;
+
+    @Autowired
+    private LoggingSlangTestCaseEventListener loggingSlangTestCaseEventListener;
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -657,6 +661,11 @@ public class SlangBuilderTest {
         @Bean
         public LoggingService loggingService() {
             return new LoggingServiceImpl();
+        }
+
+        @Bean
+        public LoggingSlangTestCaseEventListener loggingSlangTestCaseEventListener() {
+            return new LoggingSlangTestCaseEventListener();
         }
 
     }

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImplTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImplTest.java
@@ -1,0 +1,134 @@
+package io.cloudslang.lang.tools.build.logging;
+
+
+import org.apache.log4j.Level;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoggingServiceImplTest {
+
+    @InjectMocks
+    @Spy
+    private LoggingServiceImpl loggingService;
+
+    @Mock
+    private ExecutorService singleThreadExecutor;
+
+    @Test
+    public void testInitialize() throws Exception {
+        LoggingServiceImpl localLoggingService = new LoggingServiceImpl();
+
+        // Tested call
+        localLoggingService.initialize();
+
+        Class<? extends LoggingServiceImpl> loggingServiceClass = localLoggingService.getClass();
+        Field loggingServiceClassDeclaredField = loggingServiceClass.getDeclaredField("singleThreadExecutor");
+
+        loggingServiceClassDeclaredField.setAccessible(true);
+        Object singleThreadExecutor = loggingServiceClassDeclaredField.get(localLoggingService);
+
+        assertTrue(singleThreadExecutor instanceof ExecutorService);
+    }
+
+    @Test
+    public void testDestroy() throws Exception {
+        LoggingServiceImpl localLoggingService = new LoggingServiceImpl();
+        localLoggingService.initialize();
+
+        Class<? extends LoggingServiceImpl> loggingServiceClass = localLoggingService.getClass();
+        Field loggingServiceClassDeclaredField = loggingServiceClass.getDeclaredField("singleThreadExecutor");
+
+        loggingServiceClassDeclaredField.setAccessible(true);
+        Object singleThreadExecutor = loggingServiceClassDeclaredField.get(localLoggingService);
+        assertNotNull(singleThreadExecutor);
+
+        // Tested call
+        localLoggingService.destroy();
+
+        singleThreadExecutor = loggingServiceClassDeclaredField.get(localLoggingService);
+        assertNull(singleThreadExecutor);
+    }
+
+    @Test
+    public void testLogEventWithTwoParams() {
+        final List<Runnable> runnableList = new ArrayList<>();
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object[] arguments = invocationOnMock.getArguments();
+                runnableList.add((Runnable) arguments[0]);
+                return null;
+            }
+        }).when(singleThreadExecutor).submit(Mockito.any(Runnable.class));
+
+        // Tested calls
+        loggingService.logEvent(Level.INFO, "aaa");
+        loggingService.logEvent(Level.ERROR, "bbb");
+
+        assertEquals(2, runnableList.size());
+        assertTrue(runnableList.get(0) instanceof LoggingServiceImpl.LoggingDetailsRunnable);
+        assertTrue(runnableList.get(1) instanceof LoggingServiceImpl.LoggingDetailsRunnable);
+
+        assertEquals(new LoggingServiceImpl.LoggingDetailsRunnable(Level.INFO, "aaa"), runnableList.get(0));
+        assertEquals(new LoggingServiceImpl.LoggingDetailsRunnable(Level.ERROR, "bbb"), runnableList.get(1));
+    }
+
+    @Test
+    public void testLogEventWithThreeParams() {
+        final List<Runnable> runnableList = new ArrayList<>();
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object[] arguments = invocationOnMock.getArguments();
+                runnableList.add((Runnable) arguments[0]);
+                return null;
+            }
+        }).when(singleThreadExecutor).submit(Mockito.any(Runnable.class));
+
+        final RuntimeException ex1 = new RuntimeException("some exception 1");
+        final IllegalArgumentException ex2 = new IllegalArgumentException("some value does not respect its contract");
+        final IllegalStateException ex3 = new IllegalStateException("state is illegal");
+        final IllegalAccessException ex4 = new IllegalAccessException("Access denied");
+        final String message1 = "message1";
+        final String message2 = "message2";
+        final String message3 = "message3";
+        final String message4 = "message4";
+
+        // Tested calls
+        loggingService.logEvent(Level.DEBUG, message1, ex1);
+        loggingService.logEvent(Level.TRACE, message2, ex2);
+        loggingService.logEvent(Level.ERROR, message3, ex3);
+        loggingService.logEvent(Level.FATAL, message4, ex4);
+
+        assertEquals(4, runnableList.size());
+        assertTrue(runnableList.get(0) instanceof LoggingServiceImpl.LoggingDetailsRunnable);
+        assertTrue(runnableList.get(1) instanceof LoggingServiceImpl.LoggingDetailsRunnable);
+        assertTrue(runnableList.get(2) instanceof LoggingServiceImpl.LoggingDetailsRunnable);
+        assertTrue(runnableList.get(3) instanceof LoggingServiceImpl.LoggingDetailsRunnable);
+
+        assertEquals(new LoggingServiceImpl.LoggingDetailsRunnable(Level.DEBUG, message1, ex1), runnableList.get(0));
+        assertEquals(new LoggingServiceImpl.LoggingDetailsRunnable(Level.TRACE, message2, ex2), runnableList.get(1));
+        assertEquals(new LoggingServiceImpl.LoggingDetailsRunnable(Level.ERROR, message3, ex3), runnableList.get(2));
+        assertEquals(new LoggingServiceImpl.LoggingDetailsRunnable(Level.FATAL, message4, ex4), runnableList.get(3));
+    }
+
+}

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImplTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImplTest.java
@@ -26,9 +26,7 @@ import org.mockito.stubbing.Answer;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -39,17 +37,14 @@ import static org.mockito.Mockito.doAnswer;
 @RunWith(MockitoJUnitRunner.class)
 public class LoggingServiceImplTest {
 
-    public static final String SINGLE_THREAD_EXECUTOR = "singleThreadExecutor";
-    public static final String LATEST_TASK = "latestTask";
+    private static final String SINGLE_THREAD_EXECUTOR = "singleThreadExecutor";
+    private static final String LATEST_TASK = "latestTask";
     @InjectMocks
     @Spy
     private LoggingServiceImpl loggingService;
 
     @Mock
-    private ExecutorService singleThreadExecutor;
-
-    @Mock
-    private AtomicReference<Future> latestTask;
+    private ThreadPoolExecutor singleThreadExecutor;
 
     @Test
     public void testInitialize() throws Exception {
@@ -60,15 +55,11 @@ public class LoggingServiceImplTest {
 
         Class<? extends LoggingServiceImpl> loggingServiceClass = localLoggingService.getClass();
         Field loggingServiceClassDeclaredField = loggingServiceClass.getDeclaredField(SINGLE_THREAD_EXECUTOR);
-        Field latestTaskField = loggingServiceClass.getDeclaredField(LATEST_TASK);
 
         loggingServiceClassDeclaredField.setAccessible(true);
-        latestTaskField.setAccessible(true);
         Object singleThreadExecutor = loggingServiceClassDeclaredField.get(localLoggingService);
-        Object latestTask = latestTaskField.get(localLoggingService);
 
-        assertTrue(singleThreadExecutor instanceof ExecutorService);
-        assertTrue(latestTask instanceof AtomicReference);
+        assertTrue(singleThreadExecutor instanceof ThreadPoolExecutor);
     }
 
     @Test
@@ -78,22 +69,16 @@ public class LoggingServiceImplTest {
 
         Class<? extends LoggingServiceImpl> loggingServiceClass = localLoggingService.getClass();
         Field loggingServiceClassDeclaredField = loggingServiceClass.getDeclaredField(SINGLE_THREAD_EXECUTOR);
-        Field latestTaskField = loggingServiceClass.getDeclaredField(LATEST_TASK);
 
         loggingServiceClassDeclaredField.setAccessible(true);
-        latestTaskField.setAccessible(true);
         Object singleThreadExecutor = loggingServiceClassDeclaredField.get(localLoggingService);
-        Object latestTask = latestTaskField.get(localLoggingService);
         assertNotNull(singleThreadExecutor);
-        assertNotNull(latestTask);
 
         // Tested call
         localLoggingService.destroy();
 
         singleThreadExecutor = loggingServiceClassDeclaredField.get(localLoggingService);
-        latestTask = latestTaskField.get(localLoggingService);
         assertNull(singleThreadExecutor);
-        assertNull(latestTask);
     }
 
     @Test

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImplTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/logging/LoggingServiceImplTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.logging;
 
 

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
@@ -9,6 +9,8 @@ import io.cloudslang.lang.entities.ScoreLangConstants;
 import io.cloudslang.lang.entities.bindings.values.Value;
 import io.cloudslang.lang.runtime.events.LanguageEventData;
 import io.cloudslang.lang.tools.build.SlangBuildMain;
+import io.cloudslang.lang.tools.build.logging.LoggingService;
+import io.cloudslang.lang.tools.build.logging.LoggingServiceImpl;
 import io.cloudslang.lang.tools.build.tester.SlangTestRunner.TestCaseRunState;
 import io.cloudslang.lang.tools.build.tester.parallel.MultiTriggerTestCaseEventListener;
 import io.cloudslang.lang.tools.build.tester.parallel.report.LoggingSlangTestCaseEventListener;
@@ -85,7 +87,6 @@ import static org.mockito.Mockito.when;
 @ContextConfiguration(classes = SlangTestRunnerTest.Config.class)
 public class SlangTestRunnerTest {
 
-
     @Autowired
     private SlangTestRunner slangTestRunner;
 
@@ -103,6 +104,9 @@ public class SlangTestRunnerTest {
 
     @Autowired
     private TestRunInfoService testRunInfoService;
+
+    @Autowired
+    private LoggingService loggingService;
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -736,6 +740,11 @@ public class SlangTestRunnerTest {
         @Bean
         public TestRunInfoService testRunInfoServiceImpl() {
             return mock(TestRunInfoServiceImpl.class);
+        }
+
+        @Bean
+        public LoggingService loggingService() {
+            return new LoggingServiceImpl();
         }
     }
 

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
@@ -108,6 +108,9 @@ public class SlangTestRunnerTest {
     @Autowired
     private LoggingService loggingService;
 
+    @Autowired
+    private LoggingSlangTestCaseEventListener loggingSlangTestCaseEventListener;
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -745,6 +748,11 @@ public class SlangTestRunnerTest {
         @Bean
         public LoggingService loggingService() {
             return new LoggingServiceImpl();
+        }
+
+        @Bean
+        public LoggingSlangTestCaseEventListener loggingSlangTestCaseEventListener() {
+            return new LoggingSlangTestCaseEventListener();
         }
     }
 

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parser/TestCasesYamlParserTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parser/TestCasesYamlParserTest.java
@@ -23,6 +23,8 @@ import io.cloudslang.lang.entities.SystemProperty;
 import io.cloudslang.lang.entities.bindings.values.ValueFactory;
 import io.cloudslang.lang.entities.encryption.DummyEncryptor;
 import io.cloudslang.lang.entities.utils.ApplicationContextProvider;
+import io.cloudslang.lang.tools.build.logging.LoggingService;
+import io.cloudslang.lang.tools.build.logging.LoggingServiceImpl;
 import io.cloudslang.lang.tools.build.tester.parse.SlangTestCase;
 import io.cloudslang.lang.tools.build.tester.parse.TestCasesYamlParser;
 import java.io.Serializable;
@@ -64,6 +66,9 @@ public class TestCasesYamlParserTest {
 
     @Autowired
     private Slang slang;
+
+    @Autowired
+    private LoggingService loggingService;
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -231,6 +236,11 @@ public class TestCasesYamlParserTest {
         @Bean
         public SystemPropertyValidator systemPropertyValidator() {
             return new SystemPropertyValidatorImpl();
+        }
+
+        @Bean
+        public LoggingService loggingService() {
+            return new LoggingServiceImpl();
         }
     }
 }


### PR DESCRIPTION
Fixes #893 
Fixes #903
Adding logging service that handles logging requests on a dedicated thread
`cloudslang-content-verfier` incorporates the use of the new service
Also fixes an issue with the Spring context not exiting gracefully.
Signed-off-by: Lucian Musca <lucian-cristian.musca@hpe.com>