### PR TITLE
License check for cs build

### DIFF
--- a/cloudslang-all/pom.xml
+++ b/cloudslang-all/pom.xml
@@ -84,6 +84,18 @@ http://www.apache.org/licenses/LICENSE-2.0
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-all/src/main/java/io/cloudslang/lang/api/Slang.java
+++ b/cloudslang-all/src/main/java/io/cloudslang/lang/api/Slang.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.api;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-all/src/main/java/io/cloudslang/lang/api/Slang.java
+++ b/cloudslang-all/src/main/java/io/cloudslang/lang/api/Slang.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.api;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-all/src/main/java/io/cloudslang/lang/api/SlangImpl.java
+++ b/cloudslang-all/src/main/java/io/cloudslang/lang/api/SlangImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.api;
 
 import io.cloudslang.lang.compiler.MetadataExtractor;

--- a/cloudslang-all/src/main/java/io/cloudslang/lang/api/SlangImpl.java
+++ b/cloudslang-all/src/main/java/io/cloudslang/lang/api/SlangImpl.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.api;
 
 import io.cloudslang.lang.compiler.MetadataExtractor;

--- a/cloudslang-all/src/main/java/io/cloudslang/lang/api/configuration/SlangSpringConfiguration.java
+++ b/cloudslang-all/src/main/java/io/cloudslang/lang/api/configuration/SlangSpringConfiguration.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.api.configuration;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-all/src/main/java/io/cloudslang/lang/api/configuration/SlangSpringConfiguration.java
+++ b/cloudslang-all/src/main/java/io/cloudslang/lang/api/configuration/SlangSpringConfiguration.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.api.configuration;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-all/src/test/java/io/cloudslang/lang/api/SlangImplTest.java
+++ b/cloudslang-all/src/test/java/io/cloudslang/lang/api/SlangImplTest.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.api;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-all/src/test/java/io/cloudslang/lang/api/SlangImplTest.java
+++ b/cloudslang-all/src/test/java/io/cloudslang/lang/api/SlangImplTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.api;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-api-commons/pom.xml
+++ b/cloudslang-api-commons/pom.xml
@@ -45,6 +45,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/configuration/SlangCommonsSpringConfig.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/configuration/SlangCommonsSpringConfig.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.commons.configuration;
 
 import io.cloudslang.lang.api.configuration.SlangSpringConfiguration;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/configuration/SlangCommonsSpringConfig.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/configuration/SlangCommonsSpringConfig.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.commons.configuration;
 
 import io.cloudslang.lang.api.configuration.SlangSpringConfiguration;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/api/SlangSourceService.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/api/SlangSourceService.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.commons.services.api;
 
 import io.cloudslang.lang.entities.bindings.values.Value;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/api/SlangSourceService.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/api/SlangSourceService.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.commons.services.api;
 
 import io.cloudslang.lang.entities.bindings.values.Value;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/api/UserConfigurationService.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/api/UserConfigurationService.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.commons.services.api;
 
 import java.io.IOException;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/api/UserConfigurationService.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/api/UserConfigurationService.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.commons.services.api;
 
 import java.io.IOException;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/impl/SlangSourceServiceImpl.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/impl/SlangSourceServiceImpl.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.commons.services.impl;
 
 import io.cloudslang.lang.commons.services.api.SlangSourceService;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/impl/SlangSourceServiceImpl.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/impl/SlangSourceServiceImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.commons.services.impl;
 
 import io.cloudslang.lang.commons.services.api.SlangSourceService;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/impl/UserConfigurationServiceImpl.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/impl/UserConfigurationServiceImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.commons.services.impl;
 
 import io.cloudslang.lang.commons.services.api.UserConfigurationService;

--- a/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/impl/UserConfigurationServiceImpl.java
+++ b/cloudslang-api-commons/src/main/java/io/cloudslang/lang/commons/services/impl/UserConfigurationServiceImpl.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.commons.services.impl;
 
 import io.cloudslang.lang.commons.services.api.UserConfigurationService;

--- a/cloudslang-api-commons/src/test/java/io/cloudslang/lang/commons/services/impl/UserConfigurationServiceImplTest.java
+++ b/cloudslang-api-commons/src/test/java/io/cloudslang/lang/commons/services/impl/UserConfigurationServiceImplTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.commons.services.impl;
 
 import io.cloudslang.lang.commons.services.api.UserConfigurationService;

--- a/cloudslang-cli/pom.xml
+++ b/cloudslang-cli/pom.xml
@@ -264,6 +264,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangBanner.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangBanner.java
@@ -1,12 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import java.io.IOException;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangBanner.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangBanner.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import java.io.IOException;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangBootstrap.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangBootstrap.java
@@ -1,14 +1,3 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
 package io.cloudslang.lang.cli;
 
 import io.cloudslang.lang.commons.services.api.UserConfigurationService;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangBootstrap.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangBootstrap.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import io.cloudslang.lang.commons.services.api.UserConfigurationService;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangCLI.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangCLI.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangCLI.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangCLI.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangHistory.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangHistory.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import org.springframework.core.annotation.Order;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangHistory.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangHistory.java
@@ -1,12 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import org.springframework.core.annotation.Order;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangNamedProvider.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangNamedProvider.java
@@ -1,12 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import org.springframework.shell.plugin.NamedProvider;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangNamedProvider.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangNamedProvider.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import org.springframework.shell.plugin.NamedProvider;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangPrompt.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangPrompt.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import org.springframework.core.annotation.Order;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangPrompt.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/SlangPrompt.java
@@ -1,12 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import org.springframework.core.annotation.Order;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/converters/ListConverter.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/converters/ListConverter.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.converters;
 
 import java.util.ArrayList;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/converters/ListConverter.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/converters/ListConverter.java
@@ -1,12 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
 package io.cloudslang.lang.cli.converters;
 
 import java.util.ArrayList;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/converters/MapConverter.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/converters/MapConverter.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.converters;
 
 import java.util.HashMap;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/converters/MapConverter.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/converters/MapConverter.java
@@ -1,12 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
 package io.cloudslang.lang.cli.converters;
 
 import java.util.HashMap;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/ScoreServices.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/ScoreServices.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli.services;
 
 import io.cloudslang.lang.entities.CompilationArtifact;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/ScoreServices.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/ScoreServices.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.services;
 
 import io.cloudslang.lang.entities.CompilationArtifact;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/ScoreServicesImpl.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/ScoreServicesImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.services;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/ScoreServicesImpl.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/ScoreServicesImpl.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli.services;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/SyncTriggerEventListener.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/SyncTriggerEventListener.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.services;
 
 import io.cloudslang.lang.entities.ScoreLangConstants;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/SyncTriggerEventListener.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/services/SyncTriggerEventListener.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
-
 package io.cloudslang.lang.cli.services;
 
 import io.cloudslang.lang.entities.ScoreLangConstants;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/CompilerHelper.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/CompilerHelper.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.utils;
 
 import io.cloudslang.lang.compiler.modeller.result.CompilationModellingResult;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/CompilerHelper.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/CompilerHelper.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli.utils;
 
 import io.cloudslang.lang.compiler.modeller.result.CompilationModellingResult;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/CompilerHelperImpl.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/CompilerHelperImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.utils;
 
 import ch.lambdaj.function.convert.Converter;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/CompilerHelperImpl.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/CompilerHelperImpl.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli.utils;
 
 import ch.lambdaj.function.convert.Converter;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/MetadataHelper.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/MetadataHelper.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli.utils;
 
 import java.io.File;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/MetadataHelper.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/MetadataHelper.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.utils;
 
 import java.io.File;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/MetadataHelperImpl.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/MetadataHelperImpl.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli.utils;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/MetadataHelperImpl.java
+++ b/cloudslang-cli/src/main/java/io/cloudslang/lang/cli/utils/MetadataHelperImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.utils;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/MapConverterTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/MapConverterTest.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
-
 package io.cloudslang.lang.cli;
 
 import io.cloudslang.lang.cli.converters.MapConverter;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/MapConverterTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/MapConverterTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import io.cloudslang.lang.cli.converters.MapConverter;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/SlangBannerTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/SlangBannerTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import org.apache.commons.io.IOUtils;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/SlangBootstrapTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/SlangBootstrapTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import org.junit.Assert;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/SlangCLITest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/SlangCLITest.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/SlangCLITest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/SlangCLITest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/configuration/SlangCLITestConfig.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/configuration/SlangCLITestConfig.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
-
 package io.cloudslang.lang.cli.configuration;
 
 import io.cloudslang.lang.cli.services.ScoreServices;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/configuration/SlangCLITestConfig.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/configuration/SlangCLITestConfig.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.configuration;
 
 import io.cloudslang.lang.cli.services.ScoreServices;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/services/ScoreServicesImplTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/services/ScoreServicesImplTest.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
-
 package io.cloudslang.lang.cli.services;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/services/ScoreServicesImplTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/services/ScoreServicesImplTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.services;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/services/SyncTriggerEventListenerTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/services/SyncTriggerEventListenerTest.java
@@ -1,13 +1,3 @@
-/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- *******************************************************************************/
-
 package io.cloudslang.lang.cli.services;
 
 import io.cloudslang.lang.runtime.events.LanguageEventData;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/services/SyncTriggerEventListenerTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/services/SyncTriggerEventListenerTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.services;
 
 import io.cloudslang.lang.runtime.events.LanguageEventData;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/utils/CompilerHelperTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/utils/CompilerHelperTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.utils;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/utils/CompilerHelperTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/utils/CompilerHelperTest.java
@@ -1,11 +1,3 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- *
- * The Apache License is available at
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 package io.cloudslang.lang.cli.utils;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/utils/MetadataHelperTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/utils/MetadataHelperTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.cli.utils;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-compiler/pom.xml
+++ b/cloudslang-compiler/pom.xml
@@ -98,6 +98,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/Extension.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/Extension.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import java.util.Arrays;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/MetadataExtractor.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/MetadataExtractor.java
@@ -1,4 +1,4 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.modeller.model.Metadata;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/MetadataExtractorImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/MetadataExtractorImpl.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.modeller.MetadataModeller;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompiler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompiler.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.modeller.model.Executable;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompilerImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompilerImpl.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.modeller.SlangModeller;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangSource.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangSource.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.entities.SlangSystemPropertyConstant;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangTextualKeys.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangTextualKeys.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 /*******************************************************************************

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/configuration/SlangCompilerSpringConfig.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/configuration/SlangCompilerSpringConfig.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.configuration;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.configuration;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.configuration;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/DependenciesHelper.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/DependenciesHelper.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller;
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/ExecutableBuilder.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/ExecutableBuilder.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller;
 
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/MetadataModeller.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/MetadataModeller.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller;
 
 import io.cloudslang.lang.compiler.modeller.model.Metadata;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/MetadataModellerImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/MetadataModellerImpl.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller;
 
 import io.cloudslang.lang.compiler.modeller.model.Metadata;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/SlangModeller.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/SlangModeller.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller;
 
 import io.cloudslang.lang.compiler.modeller.result.ExecutableModellingResult;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/SlangModellerImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/SlangModellerImpl.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller;
 
 import io.cloudslang.lang.compiler.modeller.result.ExecutableModellingResult;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/TransformersHandler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/TransformersHandler.java
@@ -1,15 +1,14 @@
-package io.cloudslang.lang.compiler.modeller;
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller;
+
 
 import io.cloudslang.lang.compiler.modeller.result.TransformModellingResult;
 import io.cloudslang.lang.compiler.modeller.transformers.Transformer;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Action.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Action.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.model;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.model;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.model;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Decision.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Decision.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.model;
 
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Executable.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Executable.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.model;
 
 import io.cloudslang.lang.entities.bindings.Input;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Flow.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Flow.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.model;
 
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Metadata.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Metadata.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.model;
 
 import java.io.IOException;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Operation.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Operation.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.model;
 
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Step.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Step.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.model;
 
 import io.cloudslang.lang.entities.bindings.Argument;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Workflow.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/model/Workflow.java
@@ -1,5 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.model;/*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,6 +7,7 @@ package io.cloudslang.lang.compiler.modeller.model;/****************************
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.model;
 
 
 import java.util.Deque;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/ActionModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/ActionModellingResult.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import io.cloudslang.lang.compiler.modeller.model.Action;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/BasicTransformModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/BasicTransformModellingResult.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import java.util.List;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/CompilationModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/CompilationModellingResult.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import io.cloudslang.lang.entities.CompilationArtifact;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/ExecutableModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/ExecutableModellingResult.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import io.cloudslang.lang.compiler.modeller.model.Executable;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/ModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/ModellingResult.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import java.util.List;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/ParseModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/ParseModellingResult.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import io.cloudslang.lang.compiler.parser.model.ParsedSlang;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/StepModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/StepModellingResult.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import io.cloudslang.lang.compiler.modeller.model.Step;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/SystemPropertyModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/SystemPropertyModellingResult.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import io.cloudslang.lang.entities.SystemProperty;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/TransformModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/TransformModellingResult.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 /**

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/WorkflowModellingResult.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/result/WorkflowModellingResult.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.result;
 
 import io.cloudslang.lang.compiler.modeller.model.Workflow;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractForTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractForTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInOutForTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInOutForTransformer.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.entities.bindings.ScriptFunction;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInputsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInputsTransformer.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.compiler.validator.ExecutableValidator;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractOutputsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractOutputsTransformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,7 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
 
 
 import io.cloudslang.lang.compiler.modeller.result.BasicTransformModellingResult;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractTransformer.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import java.util.HashSet;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/BreakTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/BreakTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/DependencyFormatValidator.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/DependencyFormatValidator.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import org.apache.commons.lang.StringUtils;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/DoTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/DoTransformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/ForTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/ForTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/InOutTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/InOutTransformer.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.entities.bindings.InOutParam;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/InputsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/InputsTransformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/JavaActionTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/JavaActionTransformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/NavigateTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/NavigateTransformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/OutputsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/OutputsTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.compiler.modeller.result.TransformModellingResult;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/ParallelLoopForTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/ParallelLoopForTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/PublishTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/PublishTransformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/PythonActionTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/PythonActionTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/ResultsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/ResultsTransformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/Transformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/Transformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/WorkFlowTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/WorkFlowTransformer.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 /*

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/MetadataParser.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/MetadataParser.java
@@ -1,4 +1,4 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.parser;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/YamlParser.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/YamlParser.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.parser;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.parser;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.parser;
+
 
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/model/ParsedSlang.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/model/ParsedSlang.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.parser.model;
 
 import io.cloudslang.lang.compiler.Extension;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/utils/DescriptionTag.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/utils/DescriptionTag.java
@@ -1,4 +1,4 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.parser.utils;
 
 import java.util.Arrays;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/utils/ParserExceptionHandler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/parser/utils/ParserExceptionHandler.java
@@ -1,4 +1,4 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.parser.utils;
 
 import org.springframework.stereotype.Component;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ExecutionPlanBuilder.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ExecutionPlanBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler.scorecompiler;
 
 import ch.lambdaj.Lambda;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ExecutionStepFactory.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ExecutionStepFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler.scorecompiler;
 
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ScoreCompiler.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ScoreCompiler.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.scorecompiler;
 
 import io.cloudslang.lang.compiler.modeller.model.Executable;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ScoreCompilerImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/scorecompiler/ScoreCompilerImpl.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.scorecompiler;
 
 import ch.lambdaj.function.convert.Converter;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/AbstractValidator.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/AbstractValidator.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator;
 
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/CompileValidator.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/CompileValidator.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/CompileValidatorImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/CompileValidatorImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/ExecutableValidator.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/ExecutableValidator.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator;
 
 import io.cloudslang.lang.compiler.parser.model.ParsedSlang;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/ExecutableValidatorImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/ExecutableValidatorImpl.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator;
 
 import io.cloudslang.lang.compiler.parser.model.ParsedSlang;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/PreCompileValidator.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/PreCompileValidator.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator;
 
 import io.cloudslang.lang.compiler.modeller.result.ExecutableModellingResult;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/PreCompileValidatorImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/PreCompileValidatorImpl.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator;
 
 import io.cloudslang.lang.compiler.Extension;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/SystemPropertyValidator.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/SystemPropertyValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/SystemPropertyValidatorImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/SystemPropertyValidatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/NamespacePatternMatcher.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/NamespacePatternMatcher.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import io.cloudslang.lang.entities.constants.Regex;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/PatternMatcher.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/PatternMatcher.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import java.util.regex.Pattern;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/ResultNamePatternMatcher.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/ResultNamePatternMatcher.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import io.cloudslang.lang.entities.constants.Regex;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/SimpleNamePatternMatcher.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/SimpleNamePatternMatcher.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import io.cloudslang.lang.entities.constants.Regex;

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/VariableNamePatternMatcher.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/validator/matcher/VariableNamePatternMatcher.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import io.cloudslang.lang.entities.constants.Regex;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CharValidationsPreCompileErrorsTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CharValidationsPreCompileErrorsTest.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileBasicFlowTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileBasicFlowTest.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileDecisionTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileDecisionTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileDependenciesTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileDependenciesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileFlowReferenceIDTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileFlowReferenceIDTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileFlowWithMultipleStepsTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileFlowWithMultipleStepsTest.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileFlowWithOnFailureTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileFlowWithOnFailureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileForLoopsFlowTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileForLoopsFlowTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileOperationTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileOperationTest.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileParallelLoopFlowTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileParallelLoopFlowTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileResultsTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileResultsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompilerErrorsShallowValidationTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompilerErrorsShallowValidationTest.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompilerErrorsTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompilerErrorsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/DuplicateParamsErrorsTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/DuplicateParamsErrorsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/ExtensionTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/ExtensionTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import org.junit.Assert;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/LoadSystemPropertiesTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/LoadSystemPropertiesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/MetadataExtractorTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/MetadataExtractorTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/PreCompileTransformersTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/PreCompileTransformersTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/PreCompilerErrorsTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/PreCompilerErrorsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/SlangCompilerImplTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/SlangCompilerImplTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/SlangSourceTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/SlangSourceTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler;
 
 import io.cloudslang.lang.entities.SlangSystemPropertyConstant;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/DependenciesHelperTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/DependenciesHelperTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/ExecutableBuilderTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/ExecutableBuilderTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller;
 
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractTransformerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/BreakTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/BreakTransformerTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.compiler.validator.ExecutableValidator;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/DoTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/DoTransformerTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/ForTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/ForTransformerTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.compiler.validator.ExecutableValidator;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/InputsTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/InputsTransformerTest.java
@@ -1,7 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
-
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -9,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 
 import com.google.common.collect.Sets;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/JavaActionTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/JavaActionTransformerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/OutputsTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/OutputsTransformerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/ParallelLoopTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/ParallelLoopTransformerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/PublishTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/PublishTransformerTest.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 import io.cloudslang.lang.compiler.SlangSource;
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/PythonActionTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/PythonActionTransformerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/ResultsTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/ResultsTransformerTest.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.compiler.modeller.transformers;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.compiler.modeller.transformers;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.compiler.modeller.transformers;
+
 
 import io.cloudslang.lang.compiler.SlangSource;
 import io.cloudslang.lang.compiler.SlangTextualKeys;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/TransformersTestParent.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/TransformersTestParent.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
 import java.util.List;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/parser/MetadataParserTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/parser/MetadataParserTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.parser;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/parser/YamlParserTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/parser/YamlParserTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.parser;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/scorecompiler/ExecutionPlanBuilderTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/scorecompiler/ExecutionPlanBuilderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/scorecompiler/ExecutionStepFactoryTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/scorecompiler/ExecutionStepFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/SystemPropertyValidatorImplTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/SystemPropertyValidatorImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/matcher/NamespacePatternMatcherTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/matcher/NamespacePatternMatcherTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import org.junit.Before;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/matcher/ResultNamePatternMatcherTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/matcher/ResultNamePatternMatcherTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import org.junit.Before;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/matcher/SimpleNamePatternMatcherTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/matcher/SimpleNamePatternMatcherTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import org.junit.Before;

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/matcher/VariableNamePatternMatcherTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/validator/matcher/VariableNamePatternMatcherTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.compiler.validator.matcher;
 
 import org.junit.Before;

--- a/cloudslang-content-maven-compiler/pom.xml
+++ b/cloudslang-content-maven-compiler/pom.xml
@@ -79,6 +79,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-content-maven-compiler/src/main/java/io/cloudslang/maven/compiler/CloudSlangMavenCompiler.java
+++ b/cloudslang-content-maven-compiler/src/main/java/io/cloudslang/maven/compiler/CloudSlangMavenCompiler.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.maven.compiler;
 
 import io.cloudslang.lang.compiler.SlangCompiler;

--- a/cloudslang-content-maven-compiler/src/test/java/io/cloudslang/maven/compiler/CloudSlangMavenCompilerTest.java
+++ b/cloudslang-content-maven-compiler/src/test/java/io/cloudslang/maven/compiler/CloudSlangMavenCompilerTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.maven.compiler;
 
 import org.codehaus.plexus.compiler.AbstractCompilerTest;

--- a/cloudslang-content-verifier/pom.xml
+++ b/cloudslang-content-verifier/pom.xml
@@ -243,6 +243,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildResults.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuildResults.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build;
 
 import io.cloudslang.lang.tools.build.tester.IRunTestResults;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuilder.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/SlangBuilder.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build;
 
 import io.cloudslang.lang.compiler.modeller.model.Executable;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/commands/ApplicationArgs.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/commands/ApplicationArgs.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/configuration/SlangBuildSpringConfiguration.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/configuration/SlangBuildSpringConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/constants/Messages.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/constants/Messages.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.constants;
 
 /**

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/IRunTestResults.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/IRunTestResults.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester;
 
 import java.util.Map;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/ISlangTestCaseEventListener.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/ISlangTestCaseEventListener.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/RunTestsResults.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/RunTestsResults.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester;
 
 import java.util.HashMap;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestCaseRunnable.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestCaseRunnable.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/SlangTestRunner.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/TestRun.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/TestRun.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester;
 
 import io.cloudslang.lang.tools.build.tester.parse.SlangTestCase;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/TriggerTestCaseEventListener.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/TriggerTestCaseEventListener.java
@@ -1,22 +1,14 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester;
-/*
- * Licensed to Hewlett-Packard Development Company, L.P. under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
-*/
+
 
 import io.cloudslang.lang.entities.ScoreLangConstants;
 import io.cloudslang.lang.runtime.events.LanguageEventData;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/MultiTriggerTestCaseEventListener.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/MultiTriggerTestCaseEventListener.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel;
 
 import io.cloudslang.lang.runtime.events.LanguageEventData;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/report/LoggingSlangTestCaseEventListener.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/report/LoggingSlangTestCaseEventListener.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.report;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/report/SlangTestCaseRunReportGeneratorService.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/report/SlangTestCaseRunReportGeneratorService.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.report;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/report/ThreadSafeRunTestResults.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/report/ThreadSafeRunTestResults.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.report;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/services/ParallelTestCaseExecutorService.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/services/ParallelTestCaseExecutorService.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.services;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/services/TestCaseEventDispatchService.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/services/TestCaseEventDispatchService.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.services;
 
 import io.cloudslang.lang.tools.build.tester.ISlangTestCaseEventListener;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/BeginSlangTestCaseEvent.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/BeginSlangTestCaseEvent.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.testcaseevents;
 
 import io.cloudslang.lang.tools.build.tester.parse.SlangTestCase;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/FailedSlangTestCaseEvent.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/FailedSlangTestCaseEvent.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.testcaseevents;
 
 import io.cloudslang.lang.tools.build.tester.parse.SlangTestCase;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/PassedSlangTestCaseEvent.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/PassedSlangTestCaseEvent.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.testcaseevents;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/SkippedSlangTestCaseEvent.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/SkippedSlangTestCaseEvent.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.testcaseevents;
 
 

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/SlangTestCaseEvent.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parallel/testcaseevents/SlangTestCaseEvent.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.testcaseevents;
 
 import io.cloudslang.lang.tools.build.tester.parse.SlangTestCase;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parse/SlangTestCase.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parse/SlangTestCase.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parse;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parse/TestCasesYamlParser.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/parse/TestCasesYamlParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.tools.build.tester.parse;
 
 /*

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/runconfiguration/BuildModeConfig.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/tester/runconfiguration/BuildModeConfig.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.runconfiguration;
 
 import io.cloudslang.lang.compiler.modeller.model.Executable;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/validation/MetadataMissingException.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/validation/MetadataMissingException.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.validation;
 
 /**

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/validation/StaticValidator.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/validation/StaticValidator.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.validation;
 
 import io.cloudslang.lang.compiler.modeller.model.Executable;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/validation/StaticValidatorImpl.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/validation/StaticValidatorImpl.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Enterprise Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.validation;
 
 import io.cloudslang.lang.compiler.Extension;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/verifier/CompilationResult.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/verifier/CompilationResult.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Enterprise Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.verifier;
 
 import io.cloudslang.lang.compiler.modeller.model.Executable;

--- a/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/verifier/SlangContentVerifier.java
+++ b/cloudslang-content-verifier/src/main/java/io/cloudslang/lang/tools/build/verifier/SlangContentVerifier.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.verifier;
 
 import io.cloudslang.lang.compiler.Extension;

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/SlangBuilderTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/SlangBuilderTest.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build;
 
 import com.google.common.collect.Maps;

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/SlangTestRunnerTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parallel/report/SlangTestCaseRunReportGeneratorServiceTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parallel/report/SlangTestCaseRunReportGeneratorServiceTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.report;
 
 

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parallel/report/ThreadSafeRunTestResultsTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parallel/report/ThreadSafeRunTestResultsTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.report;
 
 

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parallel/services/ParallelTestCaseExecutorServiceTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parallel/services/ParallelTestCaseExecutorServiceTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.services;
 
 

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parallel/services/TestCaseEventDispatchServiceTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parallel/services/TestCaseEventDispatchServiceTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parallel.services;
 
 

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parser/TestCasesYamlParserTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/tester/parser/TestCasesYamlParserTest.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.tester.parser;
 
 import io.cloudslang.lang.api.Slang;

--- a/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/validation/StaticValidatorTest.java
+++ b/cloudslang-content-verifier/src/test/java/io/cloudslang/lang/tools/build/validation/StaticValidatorTest.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2016 Hewlett-Packard Enterprise Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.tools.build.validation;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-entities/pom.xml
+++ b/cloudslang-entities/pom.xml
@@ -112,6 +112,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ActionType.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ActionType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.entities;
 
 /**

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/CompilationArtifact.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/CompilationArtifact.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities;
 
 import io.cloudslang.lang.entities.bindings.Input;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ExecutableType.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ExecutableType.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities;
 
 /**

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ListLoopStatement.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ListLoopStatement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/LoopStatement.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/LoopStatement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/MapLoopStatement.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/MapLoopStatement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ResultNavigation.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ResultNavigation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ScoreLangConstants.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ScoreLangConstants.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities;
 
 /**

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/SlangSystemPropertyConstant.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/SlangSystemPropertyConstant.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities;
 
 /**

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/SystemProperty.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/SystemProperty.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities;
 
 import io.cloudslang.lang.entities.bindings.values.SensitiveStringValue;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Argument.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Argument.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/InOutParam.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/InOutParam.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Input.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Input.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings;
 
 import io.cloudslang.lang.entities.bindings.values.Value;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Output.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Output.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Result.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Result.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/ScriptFunction.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/ScriptFunction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/PyObjectValue.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/PyObjectValue.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 /**

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/PyObjectValueProxyClass.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/PyObjectValueProxyClass.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 import java.lang.reflect.Constructor;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/PyObjectValueProxyFactory.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/PyObjectValueProxyFactory.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 import java.io.Serializable;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/SensitiveStringValue.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/SensitiveStringValue.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 import io.cloudslang.lang.entities.encryption.EncryptionProvider;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/SensitiveValue.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/SensitiveValue.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/SimpleValue.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/SimpleValue.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/Value.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/Value.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 import java.io.Serializable;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/ValueFactory.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/ValueFactory.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 import java.io.Serializable;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/constants/Messages.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/constants/Messages.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.constants;
 
 /**

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/constants/Regex.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/constants/Regex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/encryption/DummyEncryptor.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/encryption/DummyEncryptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/encryption/EncryptionProvider.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/encryption/EncryptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ApplicationContextProvider.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ApplicationContextProvider.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import org.springframework.context.ApplicationContext;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ArgumentUtils.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ArgumentUtils.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import io.cloudslang.lang.entities.bindings.Argument;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ExpressionUtils.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ExpressionUtils.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import io.cloudslang.lang.entities.constants.Regex;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/InputUtils.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/InputUtils.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import io.cloudslang.lang.entities.bindings.Input;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ListUtils.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ListUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/MapUtils.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/MapUtils.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import io.cloudslang.lang.entities.bindings.values.Value;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ResultUtils.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ResultUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/SetUtils.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/SetUtils.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import io.cloudslang.lang.entities.SystemProperty;

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ValueUtils.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/utils/ValueUtils.java
@@ -1,11 +1,12 @@
-/*
+/*******************************************************************************
  * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import io.cloudslang.lang.entities.bindings.values.Value;

--- a/cloudslang-entities/src/test/java/io/cloudslang/fortest/SensitiveValueTest.java
+++ b/cloudslang-entities/src/test/java/io/cloudslang/fortest/SensitiveValueTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.fortest;
 
 import io.cloudslang.lang.entities.bindings.values.SensitiveValue;

--- a/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/DeserializeTest.java
+++ b/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/DeserializeTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/bindings/values/ValueFactoryTest.java
+++ b/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/bindings/values/ValueFactoryTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.bindings.values;
 
 import io.cloudslang.lang.entities.encryption.DummyEncryptor;

--- a/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/encryption/EncryptorConfigTest.java
+++ b/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/encryption/EncryptorConfigTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.encryption;
 
 import io.cloudslang.lang.entities.utils.ApplicationContextProvider;

--- a/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/utils/ExpressionUtilsTest.java
+++ b/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/utils/ExpressionUtilsTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/utils/MapUtilsTest.java
+++ b/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/utils/MapUtilsTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import io.cloudslang.lang.entities.bindings.values.Value;

--- a/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/utils/SetUtilsTest.java
+++ b/cloudslang-entities/src/test/java/io/cloudslang/lang/entities/utils/SetUtilsTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.entities.utils;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-runtime/pom.xml
+++ b/cloudslang-runtime/pom.xml
@@ -123,6 +123,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/RuntimeConstants.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/RuntimeConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/AbstractBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/AbstractBinding.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings;
 
 import io.cloudslang.lang.entities.LoopStatement;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ArgumentsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ArgumentsBinding.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings;
 
 import io.cloudslang.lang.entities.SystemProperty;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings;
 
 /*******************************************************************************

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/LoopsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/LoopsBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/OutputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/OutputsBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.bindings;
 
 import io.cloudslang.lang.entities.SystemProperty;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ParallelLoopBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ParallelLoopBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ResultsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ResultsBinding.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.runtime.bindings;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.runtime.bindings;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.runtime.bindings;
+
 
 
 import io.cloudslang.lang.entities.ScoreLangConstants;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptEvaluator.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.bindings.scripts;
 
 import io.cloudslang.lang.entities.SystemProperty;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptExecutor.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptExecutor.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings.scripts;
 
 import io.cloudslang.lang.entities.bindings.values.Value;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptProcessor.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/configuration/SlangRuntimeSpringConfig.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/configuration/SlangRuntimeSpringConfig.java
@@ -1,7 +1,5 @@
-package io.cloudslang.lang.runtime.configuration;
-
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -9,6 +7,7 @@ package io.cloudslang.lang.runtime.configuration;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.runtime.configuration;
 
 
 import io.cloudslang.lang.entities.SlangSystemPropertyConstant;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/Context.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/Context.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ContextStack.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ContextStack.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.env;
 
 import java.io.Serializable;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ExecutionPath.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ExecutionPath.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ForLoopCondition.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ForLoopCondition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/LoopCondition.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/LoopCondition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ParentFlowData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ParentFlowData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.env;
 
 import java.io.Serializable;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ParentFlowStack.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ParentFlowStack.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.env;
 
 import java.io.Serializable;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ReturnValues.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/ReturnValues.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.env;
 
 import io.cloudslang.lang.entities.bindings.values.Value;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/RunEnvironment.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/env/RunEnvironment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.env;
 
 import com.google.common.base.Function;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/events/LanguageEventData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/events/LanguageEventData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/navigations/Navigations.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/navigations/Navigations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/AbstractExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/AbstractExecutionData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ActionExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ActionExecutionData.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.steps;
 
 import com.hp.oo.sdk.content.annotations.Param;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.steps;
 
 import com.hp.oo.sdk.content.annotations.Param;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.steps;
 
 import com.hp.oo.sdk.content.annotations.Param;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ParallelLoopExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ParallelLoopExecutionData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/StepExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/StepExecutionData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/ArgumentsBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/ArgumentsBindingTest.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings;
 
 import io.cloudslang.dependency.api.services.DependencyService;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/InputsBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/InputsBindingTest.java
@@ -1,12 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- */
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings;
 
 import io.cloudslang.dependency.api.services.DependencyService;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/LoopsBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/LoopsBindingTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings;
 
 import io.cloudslang.lang.entities.ListLoopStatement;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/OutputsBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/OutputsBindingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.bindings;
 
 import io.cloudslang.dependency.api.services.DependencyService;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/ParallelLoopBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/ParallelLoopBindingTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings;
 
 import io.cloudslang.lang.entities.ListLoopStatement;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/ResultBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/ResultBindingTest.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.runtime.bindings;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.runtime.bindings;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.runtime.bindings;
+
 
 
 import io.cloudslang.dependency.api.services.DependencyService;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptEvaluatorTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptEvaluatorTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings.scripts;
 
 import io.cloudslang.dependency.api.services.DependencyService;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptExecutorTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptExecutorTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.bindings.scripts;
 
 import io.cloudslang.dependency.api.services.DependencyService;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/env/ExecutionPathTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/env/ExecutionPathTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/env/RunEnvironmentSensitiveTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/env/RunEnvironmentSensitiveTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.runtime.env;
 
 import io.cloudslang.lang.entities.SystemProperty;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/events/LanguageEventDataTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/events/LanguageEventDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/navigations/NavigationsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/navigations/NavigationsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.navigations;
 
 import io.cloudslang.lang.entities.ScoreLangConstants;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ActionStepsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ActionStepsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.steps;
 
 import com.hp.oo.sdk.content.plugin.GlobalSessionObject;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ContentTestActions.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ContentTestActions.java
@@ -1,6 +1,5 @@
-package io.cloudslang.lang.runtime.steps;
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -8,6 +7,8 @@ package io.cloudslang.lang.runtime.steps;
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
+package io.cloudslang.lang.runtime.steps;
+
 
 
 import com.hp.oo.sdk.content.annotations.Param;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.runtime.steps;
 
 import io.cloudslang.dependency.api.services.DependencyService;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ParallelLoopStepsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ParallelLoopStepsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/StepExecutionDataTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/StepExecutionDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-spi/pom.xml
+++ b/cloudslang-spi/pom.xml
@@ -34,6 +34,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-spi/src/main/java/io/cloudslang/lang/spi/encryption/Encryption.java
+++ b/cloudslang-spi/src/main/java/io/cloudslang/lang/spi/encryption/Encryption.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-tests/pom.xml
+++ b/cloudslang-tests/pom.xml
@@ -110,6 +110,17 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.parent.basedir}/license.template</header>
+                    <headerDefinitions>
+                        <headerDefinition>${project.parent.basedir}/header-definitions.xml</headerDefinition>
+                    </headerDefinitions>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/AbstractAggregatorListener.java
+++ b/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/AbstractAggregatorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/BranchAggregatorListener.java
+++ b/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/BranchAggregatorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/JoinAggregatorListener.java
+++ b/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/JoinAggregatorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/RunDataAggregatorListener.java
+++ b/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/RunDataAggregatorListener.java
@@ -1,15 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
-
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import ch.lambdaj.group.Group;

--- a/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/RuntimeInformation.java
+++ b/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/RuntimeInformation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/StepData.java
+++ b/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/StepData.java
@@ -1,13 +1,12 @@
-/******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * *****************************************************************************/
-
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import java.io.Serializable;

--- a/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/TriggerFlows.java
+++ b/cloudslang-tests/src/main/java/io/cloudslang/lang/systemtests/TriggerFlows.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/BindingScopeTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/BindingScopeTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/FlowWithJavaVersioningTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/FlowWithJavaVersioningTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 /**

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/FlowWithPythonVersioningTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/FlowWithPythonVersioningTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 /**

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/LoopFlowsTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/LoopFlowsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/OperationSystemTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/OperationSystemTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.systemtests;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/OperationWithDependenciesSystemTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/OperationWithDependenciesSystemTest.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/ParallelLoopFlowsTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/ParallelLoopFlowsTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import com.google.common.collect.Lists;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SimpleFlowTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SimpleFlowTest.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SimpleOperationTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SimpleOperationTest.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SubFlowSystemTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SubFlowSystemTest.java
@@ -1,11 +1,12 @@
-/*
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SystemsTestsParent.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/SystemsTestsParent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.systemtests;
 
 import io.cloudslang.dependency.impl.services.MavenConfigImpl;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/ValueSyntaxParent.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/ValueSyntaxParent.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/actions/LangTestActions.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/actions/LangTestActions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.systemtests.actions;
 
 import com.hp.oo.sdk.content.annotations.Param;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/decisions/DecisionsTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/decisions/DecisionsTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.decisions;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/DataFlowTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/DataFlowTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.systemtests.flows;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/FunctionDependenciesTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/FunctionDependenciesTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.flows;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/NavigationTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/NavigationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -7,7 +7,6 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  *******************************************************************************/
-
 package io.cloudslang.lang.systemtests.flows;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/ValueSyntaxInFlowTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/ValueSyntaxInFlowTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.flows;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/ValueSyntaxInOperationTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/flows/ValueSyntaxInOperationTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.flows;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValueOperationTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValueOperationTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.sensitive;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValueSyntaxInFlowTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValueSyntaxInFlowTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.sensitive;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValuesDecisionTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValuesDecisionTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.sensitive;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValuesInPythonExpressionsFlowTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValuesInPythonExpressionsFlowTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.sensitive;
 
 import com.google.common.collect.Sets;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValuesInPythonExpressionsOperationTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/sensitive/SensitiveValuesInPythonExpressionsOperationTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.sensitive;
 
 import io.cloudslang.lang.compiler.SlangSource;

--- a/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/system_properties/SensitiveSystemPropertiesTest.java
+++ b/cloudslang-tests/src/test/java/io/cloudslang/lang/systemtests/system_properties/SensitiveSystemPropertiesTest.java
@@ -1,14 +1,12 @@
-/**
- * ****************************************************************************
- * (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
- * <p/>
+ *
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * *****************************************************************************
- */
+ *
+ *******************************************************************************/
 package io.cloudslang.lang.systemtests.system_properties;
 
 import com.google.common.collect.Sets;

--- a/header-definitions.xml
+++ b/header-definitions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<additionalHeaders>
+    <cloudslang-java-header>
+        <firstLine>/*******************************************************************************</firstLine>
+        <beforeEachLine> </beforeEachLine>
+        <endLine> *******************************************************************************/</endLine>
+        <afterEachLine> </afterEachLine>
+        <firstLineDetectionPattern>/[*]{79}</firstLineDetectionPattern>
+        <lastLineDetectionPattern> [*]{79}/</lastLineDetectionPattern>
+        <allowBlankLines>false</allowBlankLines>
+        <isMultiline>true</isMultiline>
+        <padLines>false</padLines>
+    </cloudslang-java-header>
+</additionalHeaders>

--- a/license.template
+++ b/license.template
@@ -1,0 +1,7 @@
+* (c) Copyright ${copyright.year} Hewlett-Packard Development Company, L.P.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Apache License v2.0 which accompany this distribution.
+*
+* The Apache License is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*

--- a/pom.xml
+++ b/pom.xml
@@ -645,15 +645,15 @@
         </profile>
     </profiles>
     <modules>
-        <!--<module>cloudslang-spi</module>-->
-        <!--<module>cloudslang-runtime</module>-->
-        <!--<module>cloudslang-compiler</module>-->
-        <!--<module>cloudslang-entities</module>-->
-        <!--<module>cloudslang-cli</module>-->
-        <!--<module>cloudslang-tests</module>-->
+        <module>cloudslang-spi</module>
+        <module>cloudslang-runtime</module>
+        <module>cloudslang-compiler</module>
+        <module>cloudslang-entities</module>
+        <module>cloudslang-cli</module>
+        <module>cloudslang-tests</module>
         <module>cloudslang-all</module>
-        <!--<module>cloudslang-content-verifier</module>-->
-        <!--<module>cloudslang-content-maven-compiler</module>-->
-        <!--<module>cloudslang-api-commons</module>-->
+        <module>cloudslang-content-verifier</module>
+        <module>cloudslang-content-maven-compiler</module>
+        <module>cloudslang-api-commons</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,34 @@
                         </execution>
                     </executions>
                 </plugin>
+                <!--License checker for build-->
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>3.0</version>
+                    <configuration>
+                        <includes>
+                            <include>**/*.java</include>
+                        </includes>
+                        <!--Pass arguments using ${var} syntax in license.template file-->
+                        <properties>
+                            <copyright.year>2016</copyright.year>
+                        </properties>
+                        <!--Custom mapping for java extensions-->
+                        <useDefaultMapping>false</useDefaultMapping>
+                        <mapping>
+                            <java>cloudslang-java-header</java>
+                        </mapping>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>format</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
             </plugins>
         </pluginManagement>
@@ -617,15 +645,15 @@
         </profile>
     </profiles>
     <modules>
-        <module>cloudslang-spi</module>
-        <module>cloudslang-runtime</module>
-        <module>cloudslang-compiler</module>
-        <module>cloudslang-entities</module>
-        <module>cloudslang-cli</module>
-        <module>cloudslang-tests</module>
+        <!--<module>cloudslang-spi</module>-->
+        <!--<module>cloudslang-runtime</module>-->
+        <!--<module>cloudslang-compiler</module>-->
+        <!--<module>cloudslang-entities</module>-->
+        <!--<module>cloudslang-cli</module>-->
+        <!--<module>cloudslang-tests</module>-->
         <module>cloudslang-all</module>
-        <module>cloudslang-content-verifier</module>
-        <module>cloudslang-content-maven-compiler</module>
-        <module>cloudslang-api-commons</module>
+        <!--<module>cloudslang-content-verifier</module>-->
+        <!--<module>cloudslang-content-maven-compiler</module>-->
+        <!--<module>cloudslang-api-commons</module>-->
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@
                         <execution>
                             <phase>process-resources</phase>
                             <goals>
-                                <goal>format</goal>
+                                <goal>check</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
From now on, the license check will be applied on all java sources from roots `test`, `main`
on each module of the multi-module project. 
The check will fail the build for missing header or typos in header.

Signed-off-by: Lucian Musca <lucian-cristian.musca@hpe.com>