### PR TITLE
Do not remove current executable from compile dependencies

### DIFF
--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompilerImpl.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangCompilerImpl.java
@@ -28,6 +28,10 @@ import io.cloudslang.lang.entities.SensitivityLevel;
 import io.cloudslang.lang.entities.SystemProperty;
 import io.cloudslang.lang.entities.bindings.values.ValueFactory;
 import io.cloudslang.lang.entities.utils.SetUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.NotImplementedException;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,9 +40,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang.Validate;
-import org.apache.commons.lang3.NotImplementedException;
 
 import static io.cloudslang.lang.compiler.SlangTextualKeys.SENSITIVE_KEY;
 import static io.cloudslang.lang.compiler.SlangTextualKeys.VALUE_KEY;
@@ -143,8 +144,6 @@ public class SlangCompilerImpl implements SlangCompiler {
                 executablePairs.put(preCompiledCurrentSource, currentSource);
             }
         }
-
-        executablePairs.remove(executableModellingResult.getExecutable());
 
         CompilationModellingResult result = scoreCompiler
                 .compileSource(executableModellingResult.getExecutable(), executablePairs.keySet());

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileDependenciesTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompileDependenciesTest.java
@@ -14,11 +14,6 @@ import io.cloudslang.lang.entities.CompilationArtifact;
 import io.cloudslang.lang.entities.ScoreLangConstants;
 import io.cloudslang.score.api.ExecutionPlan;
 import io.cloudslang.score.api.ExecutionStep;
-
-import java.net.URI;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -29,6 +24,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -54,12 +53,6 @@ public class CompileDependenciesTest {
         final URI flow = getClass().getResource("/basic_flow.yaml").toURI();
         Set<SlangSource> path = new HashSet<>();
         compiler.compile(SlangSource.fromFile(flow), path);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void nullPathButThereAreImports() throws Exception {
-        final URI flow = getClass().getResource("/basic_flow.yaml").toURI();
-        compiler.compile(SlangSource.fromFile(flow), null);
     }
 
     @Test
@@ -173,6 +166,15 @@ public class CompileDependenciesTest {
 
         Assert.assertTrue(path.contains(flowSource));
         CompilationArtifact compilationArtifact = compiler.compile(flowSource, path);
+        Assert.assertNotNull(compilationArtifact);
+    }
+
+    @Test
+    public void testCompileWorksForSingleSelfReference() throws Exception {
+        final URI executable = getClass().getResource("/cornercases/selfreference.sl").toURI();
+        SlangSource executableSource = SlangSource.fromFile(executable);
+
+        CompilationArtifact compilationArtifact = compiler.compile(executableSource, new HashSet<SlangSource>());
         Assert.assertNotNull(compilationArtifact);
     }
 

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompilerErrorsTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/CompilerErrorsTest.java
@@ -12,13 +12,6 @@ package io.cloudslang.lang.compiler;
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;
 import io.cloudslang.lang.compiler.modeller.result.CompilationModellingResult;
 import io.cloudslang.lang.compiler.parser.utils.ParserExceptionHandler;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.HashSet;
-import java.util.Set;
-
-import junit.framework.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -27,6 +20,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
 
@@ -280,17 +278,6 @@ public class CompilerErrorsTest {
         exception.expectMessage("Cannot compile flow 'step_with_missing_navigation_from_operation_result_flow' " +
                 "since for step 'step1' the results [FAILURE] of its dependency 'user.ops.java_op' " +
                 "have no matching navigation.");
-        compiler.compile(SlangSource.fromFile(resource), path);
-    }
-
-    @Test
-    public void testFlowWithMissingImports() throws Exception {
-        final URI resource = getClass().getResource("/corrupted/missing_dependencies_imports_flow.sl").toURI();
-
-        final Set<SlangSource> path = new HashSet<>();
-        exception.expect(RuntimeException.class);
-        exception.expectMessage("Source missing_dependencies_imports_flow has " +
-                "dependencies but no path was given to the compiler");
         compiler.compile(SlangSource.fromFile(resource), path);
     }
 

--- a/cloudslang-compiler/src/test/resources/cornercases/selfreference.sl
+++ b/cloudslang-compiler/src/test/resources/cornercases/selfreference.sl
@@ -1,0 +1,18 @@
+#   (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Apache License v2.0 which accompany this distribution.
+#
+#   The Apache License is available at
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+namespace: io.cloudslang
+
+imports:
+ cs: io.cloudslang
+
+flow:
+  name: selfreference
+  workflow:
+    - ref:
+        do:
+          cs.selfreference: []


### PR DESCRIPTION
Fix case - should compile: flow with single step that references itself

Signed-off-by: Levente Bonczidai <levente.bonczidai@hpe.com>