### PR TITLE
upgrade spring and score

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
         <maven-license-plugin.version>3.0</maven-license-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <!--Project dependencies-->
-        <spring.version>4.3.10.RELEASE</spring.version>
+        <spring.version>4.3.17.RELEASE</spring.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <score.version>0.3.50</score.version>
+        <score.version>0.3.53</score.version>
         <!--Project properties-->
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!--Project dependencies-->
         <spring.version>4.3.17.RELEASE</spring.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <score.version>0.3.53</score.version>
+        <score.version>0.3.54</score.version>
         <!--Project properties-->
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>


### PR DESCRIPTION
Updated spring.version dependency to: 4.3.10.RELEASE
Contains changes from the score project: https://github.com/CloudSlang/score/pull/155
Updated score.version dependency to: 0.3.54