### PR TITLE
Fix cloudslang-cli startup on Java 9 version and above. (java.xml.bin…

### DIFF
--- a/cloudslang-cli/pom.xml
+++ b/cloudslang-cli/pom.xml
@@ -164,6 +164,14 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!--JAX-B APIs-->
+        <!-- Needed at startup by CLI (starting with Java 9 - java.xml.bind module not resolved by default on classpath -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
         <!-- test -->
         <dependency>
             <groupId>org.mockito</groupId>
@@ -273,6 +281,9 @@
                         </goals>
                         <configuration>
                             <failOnWarning>true</failOnWarning>
+                            <ignoredUnusedDeclaredDependencies>
+                                <ignoredUnusedDeclaredDependency>javax.xml.bind:jaxb-api:jar:2.3.0</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
…d module is not resolved by default on classpath and has been marked deprecated - expected to be completely removed)

Signed-off-by: George Giloan <giloan@hpe.com>