### PR TITLE
Fixed parsing of special characters with snakeyaml-1.25

### DIFF
--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/configuration/SlangCompilerSpringConfig.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/configuration/SlangCompilerSpringConfig.java
@@ -439,7 +439,7 @@ public class SlangCompilerSpringConfig {
         Constructor constructor = new Constructor(ParsedSlang.class);
         constructor.setPropertyUtils(new PropertyUtils() {
             @Override
-            public Property getProperty(Class<? extends Object> type, String name) throws IntrospectionException {
+            public Property getProperty(Class<? extends Object> type, String name) {
                 if (name.equals(OBJECT_REPOSITORY_KEY)) {
                     name = OBJECT_REPOSITORY_CAMEL_CASE;
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.16</version>
+                <version>1.18</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.18</version>
+                <version>1.25</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixed the problem with parsing emoji in comments that is fixed in snakeyaml-1.18. See:
https://bitbucket.org/asomov/snakeyaml/issues/323/is-there-any-reason-to-not-support