### PR TITLE
list iterator fix for designer

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
@@ -147,9 +147,8 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
     private void handleSessionContextArgument(Map sessionData, String objectClassName, List<Object> args,
                                               String parameterName, ClassLoader classLoader) {
         // cloudslang list iterator fix
-        if (this.nodeNameWithDepth.startsWith("list_iterator")) {
-            parameterName = this.nodeNameWithDepth;
-        }
+        parameterName = this.nodeNameWithDepth.startsWith("list_iterator") ? this.nodeNameWithDepth : parameterName ;
+
         Object sessionContextObject = sessionData.get(parameterName);
         if (sessionContextObject == null) {
             try {

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
@@ -147,7 +147,8 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
     private void handleSessionContextArgument(Map sessionData, String objectClassName, List<Object> args,
                                               String parameterName, ClassLoader classLoader) {
         // cloudslang list iterator fix
-        final String parameter = this.nodeNameWithDepth.startsWith("list_iterator") ? this.nodeNameWithDepth : parameterName ;
+        final String parameter = this.nodeNameWithDepth.startsWith("list_iterator") ?
+                                             this.nodeNameWithDepth : parameterName ;
 
         Object sessionContextObject = sessionData.get(parameter);
         if (sessionContextObject == null) {

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
@@ -147,9 +147,9 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
     private void handleSessionContextArgument(Map sessionData, String objectClassName, List<Object> args,
                                               String parameterName, ClassLoader classLoader) {
         // cloudslang list iterator fix
-        parameterName = this.nodeNameWithDepth.startsWith("list_iterator") ? this.nodeNameWithDepth : parameterName ;
+        final String parameter = this.nodeNameWithDepth.startsWith("list_iterator") ? this.nodeNameWithDepth : parameterName ;
 
-        Object sessionContextObject = sessionData.get(parameterName);
+        Object sessionContextObject = sessionData.get(parameter);
         if (sessionContextObject == null) {
             try {
                 sessionContextObject = Class.forName(objectClassName, true, classLoader).newInstance();
@@ -157,7 +157,7 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
                 throw new RuntimeException("Failed to create instance of [" + objectClassName + "] class", e);
             }
             //noinspection unchecked
-            sessionData.put(parameterName, sessionContextObject);
+            sessionData.put(parameter, sessionContextObject);
         }
         args.add(sessionContextObject);
     }

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
@@ -146,6 +146,10 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
 
     private void handleSessionContextArgument(Map sessionData, String objectClassName, List<Object> args,
                                               String parameterName, ClassLoader classLoader) {
+        // cloudslang list iterator fix
+        if (this.nodeNameWithDepth.startsWith("list_iterator")) {
+            parameterName = this.nodeNameWithDepth;
+        }
         Object sessionContextObject = sessionData.get(parameterName);
         if (sessionContextObject == null) {
             try {


### PR DESCRIPTION
In case of nested iterators context is not being passed correctly . I changed the way how the context is passed to cloudslang content.

Existing Behaviour : In nested scenario same context is being passed to all the iteraors and causing the nested iterators to run forever.
Modified Behaviour: One context object for each iterator in nested scenario. 

Signed-off-by: Mallikarjuna <mallikarjunareddy.tipparreddy@microfocus.com>