### PR TITLE
Added prompt to input definition

### DIFF
--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangTextualKeys.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/SlangTextualKeys.java
@@ -87,6 +87,11 @@ public interface SlangTextualKeys {
     String SENSITIVE_KEY = "sensitive";
     String PRIVATE_INPUT_KEY = "private";
     String SEQ_OUTPUT_ROBOT_KEY = "robot";
+    String PROMPT_KEY = "prompt";
+    String PROMPT_TYPE_KEY = "type";
+    String PROMPT_MESSAGE_KEY = "message";
+    String PROMPT_OPTIONS_KEY = "options";
+    String PROMPT_DELIMITER_KEY = "delimiter";
 
     // system properties
     String SYSTEM_PROPERTY_KEY = "properties";

--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInputsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/AbstractInputsTransformer.java
@@ -9,25 +9,44 @@
  *******************************************************************************/
 package io.cloudslang.lang.compiler.modeller.transformers;
 
+import io.cloudslang.lang.entities.PromptType;
 import io.cloudslang.lang.entities.SensitivityLevel;
 import io.cloudslang.lang.compiler.validator.ExecutableValidator;
 import io.cloudslang.lang.compiler.validator.PreCompileValidator;
 import io.cloudslang.lang.entities.bindings.InOutParam;
 import io.cloudslang.lang.entities.bindings.Input;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+
+
+import static com.google.common.collect.Sets.newHashSet;
 import static io.cloudslang.lang.compiler.SlangTextualKeys.DEFAULT_KEY;
 import static io.cloudslang.lang.compiler.SlangTextualKeys.PRIVATE_INPUT_KEY;
+import static io.cloudslang.lang.compiler.SlangTextualKeys.PROMPT_DELIMITER_KEY;
+import static io.cloudslang.lang.compiler.SlangTextualKeys.PROMPT_KEY;
+import static io.cloudslang.lang.compiler.SlangTextualKeys.PROMPT_MESSAGE_KEY;
+import static io.cloudslang.lang.compiler.SlangTextualKeys.PROMPT_OPTIONS_KEY;
+import static io.cloudslang.lang.compiler.SlangTextualKeys.PROMPT_TYPE_KEY;
 import static io.cloudslang.lang.compiler.SlangTextualKeys.REQUIRED_KEY;
 import static io.cloudslang.lang.compiler.SlangTextualKeys.SENSITIVE_KEY;
 import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.collections4.MapUtils.isNotEmpty;
 
 public abstract class AbstractInputsTransformer extends InOutTransformer {
+
+    private static final String DEFAULT_PROMPT_MESSAGE = "Enter a value for '%s'";
+    private static final HashSet<String> KNOWN_KEYS = newHashSet(
+            REQUIRED_KEY,
+            SENSITIVE_KEY,
+            PRIVATE_INPUT_KEY,
+            DEFAULT_KEY,
+            PROMPT_KEY);
+    private static final String DEFAULT_DELIMITER = ",";
 
     protected PreCompileValidator preCompileValidator;
 
@@ -78,28 +97,42 @@ public abstract class AbstractInputsTransformer extends InOutTransformer {
     private Input createPropInput(Map.Entry<String, Map<String, Serializable>> entry,
                                   SensitivityLevel sensitivityLevel) {
         Map<String, Serializable> props = entry.getValue();
-        List<String> knownKeys = Arrays.asList(REQUIRED_KEY, SENSITIVE_KEY, PRIVATE_INPUT_KEY, DEFAULT_KEY);
 
         for (String key : props.keySet()) {
-            if (!knownKeys.contains(key)) {
+            if (!KNOWN_KEYS.contains(key)) {
                 throw new RuntimeException(format("key: %s in input: %s is not a known property",
                         key, entry.getKey()));
             }
         }
 
         // default is required=true
-        boolean required = !props.containsKey(REQUIRED_KEY) ||
-                (boolean) props.get(REQUIRED_KEY);
+        boolean required = (boolean) props.getOrDefault(REQUIRED_KEY, true);
         // default is sensitive=false
-        boolean sensitive = props.containsKey(SENSITIVE_KEY) &&
-                (boolean) props.get(SENSITIVE_KEY);
+        boolean sensitive = (boolean) props.getOrDefault(SENSITIVE_KEY, false);
         // default is private=false
-        boolean privateInput = props.containsKey(PRIVATE_INPUT_KEY) &&
-                (boolean) props.get(PRIVATE_INPUT_KEY);
+        boolean privateInput = (boolean) props.getOrDefault(PRIVATE_INPUT_KEY, false);
+
         boolean defaultKeyFound = props.containsKey(DEFAULT_KEY);
-        String inputName = entry.getKey();
-        Serializable value = defaultKeyFound ? props.get(DEFAULT_KEY) : null;
+        final String inputName = entry.getKey();
+        final Serializable value = defaultKeyFound ? props.get(DEFAULT_KEY) : null;
         boolean defaultSpecified = defaultKeyFound && value != null && !StringUtils.EMPTY.equals(value);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> promptSettings = (Map<String, String>) props.get(PROMPT_KEY);
+        if (!privateInput && isNotEmpty(promptSettings)) {
+            final PromptType type = ofNullable(promptSettings.get(PROMPT_TYPE_KEY))
+                    .map(PromptType::fromString)
+                    .orElse(PromptType.TEXT);
+
+            final String message = ofNullable(promptSettings.get(PROMPT_MESSAGE_KEY))
+                    .orElseGet(() -> String.format(DEFAULT_PROMPT_MESSAGE, inputName));
+
+            final String options = promptSettings.get(PROMPT_OPTIONS_KEY);
+            final String delimiter = promptSettings.getOrDefault(PROMPT_DELIMITER_KEY, DEFAULT_DELIMITER);
+
+            return createInput(inputName, value, sensitive, required, privateInput, sensitivityLevel,
+                    type, message, options, delimiter);
+        }
 
         if (privateInput && required && !defaultSpecified) {
             throw new RuntimeException(PreCompileValidator.VALIDATION_ERROR +
@@ -121,6 +154,16 @@ public abstract class AbstractInputsTransformer extends InOutTransformer {
             boolean sensitive,
             boolean required,
             boolean privateInput, SensitivityLevel sensitivityLevel) {
+        return createInput(name, value, sensitive, required, privateInput, sensitivityLevel, null, null, null, null);
+    }
+
+    private Input createInput(
+            String name,
+            Serializable value,
+            boolean sensitive,
+            boolean required,
+            boolean privateInput, SensitivityLevel sensitivityLevel,
+            PromptType promptType, String message, String options, String delimiter) {
         executableValidator.validateInputName(name);
         preCompileValidator.validateStringValue(name, value, this);
         Accumulator dependencyAccumulator = extractFunctionData(value);
@@ -129,6 +172,10 @@ public abstract class AbstractInputsTransformer extends InOutTransformer {
                 .withPrivateInput(privateInput)
                 .withFunctionDependencies(dependencyAccumulator.getFunctionDependencies())
                 .withSystemPropertyDependencies(dependencyAccumulator.getSystemPropertyDependencies())
+                .withPrompt(promptType)
+                .withPromptMessage(message)
+                .withPromptOptions(options)
+                .withPromptDelimiter(delimiter)
                 .build();
     }
 

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/PreCompileTransformersTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/PreCompileTransformersTest.java
@@ -243,6 +243,12 @@ public class PreCompileTransformersTest {
         assertEquals(flowInput2.getPromptMessage(), "Enter a value for 'flow_input_2'");
         assertNull(flowInput2.getPromptOptions());
         assertEquals(flowInput2.getPromptDelimiter(), ",");
+
+        Input flowInput3 = inputs.get(2);
+        assertEquals(flowInput3.getPromptType(), PromptType.SINGLE_CHOICE);
+
+        Input flowInput4 = inputs.get(3);
+        assertEquals(flowInput4.getPromptType(), PromptType.MULTI_CHOICE);
     }
 
 }

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/PreCompileTransformersTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/PreCompileTransformersTest.java
@@ -12,15 +12,16 @@ package io.cloudslang.lang.compiler;
 import io.cloudslang.lang.compiler.configuration.SlangCompilerSpringConfig;
 import io.cloudslang.lang.compiler.modeller.model.Executable;
 import io.cloudslang.lang.compiler.modeller.result.ExecutableModellingResult;
+import io.cloudslang.lang.entities.PromptType;
 import io.cloudslang.lang.entities.bindings.Input;
 import io.cloudslang.lang.entities.bindings.Output;
 import io.cloudslang.lang.entities.bindings.Result;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 
-import junit.framework.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,6 +30,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
 
 /**
  * @author Bonczidai Levente
@@ -50,16 +56,16 @@ public class PreCompileTransformersTest {
         URI resource = getClass().getResource("/corrupted/transformers/operation_input_private_no_default.sl").toURI();
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource));
 
-        Assert.assertNotNull(result);
+        assertNotNull(result);
 
         Executable executable = result.getExecutable();
-        Assert.assertNotNull(executable);
+        assertNotNull(executable);
         List<Input> inputs = executable.getInputs();
-        Assert.assertEquals(6, inputs.size());
+        assertEquals(6, inputs.size());
 
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertTrue(errors.size() > 0);
+        assertNotNull(errors);
+        assertTrue(errors.size() > 0);
         exception.expect(RuntimeException.class);
         exception.expectMessage("For operation 'operation_input_private_no_default' syntax is illegal.");
         exception.expectMessage("Input: 'input_private_no_default' is private " +
@@ -72,32 +78,32 @@ public class PreCompileTransformersTest {
         URI resource = getClass().getResource("/check_weather_flow_sensitive_inputs_outputs.sl").toURI();
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource));
 
-        Assert.assertNotNull(result);
+        assertNotNull(result);
 
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertTrue(errors.size() == 0);
+        assertNotNull(errors);
+        assertTrue(errors.size() == 0);
         Executable executable = result.getExecutable();
-        Assert.assertNotNull(executable);
+        assertNotNull(executable);
         List<Input> inputs = executable.getInputs();
-        Assert.assertEquals(3, inputs.size());
-        Assert.assertEquals("flow_input_1", inputs.get(0).getName());
-        Assert.assertEquals("defaultValue", inputs.get(0).getValue().get());
-        Assert.assertEquals(false, inputs.get(0).getValue().isSensitive());
-        Assert.assertEquals("flow_input_0", inputs.get(1).getName());
-        Assert.assertEquals("${flow_input_1}", inputs.get(1).getValue().get());
-        Assert.assertEquals(true, inputs.get(1).getValue().isSensitive());
-        Assert.assertEquals("flow_input_sensitive", inputs.get(2).getName());
-        Assert.assertEquals(null, inputs.get(2).getValue().get());
-        Assert.assertEquals(true, inputs.get(2).getValue().isSensitive());
+        assertEquals(3, inputs.size());
+        assertEquals("flow_input_1", inputs.get(0).getName());
+        assertEquals("defaultValue", inputs.get(0).getValue().get());
+        assertEquals(false, inputs.get(0).getValue().isSensitive());
+        assertEquals("flow_input_0", inputs.get(1).getName());
+        assertEquals("${flow_input_1}", inputs.get(1).getValue().get());
+        assertEquals(true, inputs.get(1).getValue().isSensitive());
+        assertEquals("flow_input_sensitive", inputs.get(2).getName());
+        assertEquals(null, inputs.get(2).getValue().get());
+        assertEquals(true, inputs.get(2).getValue().isSensitive());
         List<Output> outputs = executable.getOutputs();
-        Assert.assertEquals(2, outputs.size());
-        Assert.assertEquals("flow_output_0", outputs.get(0).getName());
-        Assert.assertEquals("${flow_input_1}", outputs.get(0).getValue().get());
-        Assert.assertEquals(true, outputs.get(0).getValue().isSensitive());
-        Assert.assertEquals("flow_output_1", outputs.get(1).getName());
-        Assert.assertEquals("${flow_output_1}", outputs.get(1).getValue().get());
-        Assert.assertEquals(true, outputs.get(1).getValue().isSensitive());
+        assertEquals(2, outputs.size());
+        assertEquals("flow_output_0", outputs.get(0).getName());
+        assertEquals("${flow_input_1}", outputs.get(0).getValue().get());
+        assertEquals(true, outputs.get(0).getValue().isSensitive());
+        assertEquals("flow_output_1", outputs.get(1).getName());
+        assertEquals("${flow_output_1}", outputs.get(1).getValue().get());
+        assertEquals(true, outputs.get(1).getValue().isSensitive());
     }
 
     @Test
@@ -105,8 +111,8 @@ public class PreCompileTransformersTest {
         URI flow = getClass().getResource("/check_weather_flow_sensitive.sl").toURI();
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(flow));
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertEquals(0, errors.size());
+        assertNotNull(errors);
+        assertEquals(0, errors.size());
     }
 
     @Test
@@ -115,8 +121,8 @@ public class PreCompileTransformersTest {
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource.toURI()));
 
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertTrue(errors.size() > 0);
+        assertNotNull(errors);
+        assertTrue(errors.size() > 0);
 
         exception.expect(RuntimeException.class);
         exception.expectMessage("For operation 'check_weather_optional_input_boolean' syntax is illegal.");
@@ -131,8 +137,8 @@ public class PreCompileTransformersTest {
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource.toURI()));
 
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertTrue(errors.size() > 0);
+        assertNotNull(errors);
+        assertTrue(errors.size() > 0);
         exception.expect(RuntimeException.class);
         exception.expectMessage("For operation 'check_weather_optional_input_default_integer' syntax is illegal.");
         exception.expectMessage("Input: 'input_with_default_value' should have a String value, but got value '2' " +
@@ -147,8 +153,8 @@ public class PreCompileTransformersTest {
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource.toURI()));
 
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertTrue(errors.size() > 0);
+        assertNotNull(errors);
+        assertTrue(errors.size() > 0);
         exception.expect(RuntimeException.class);
         exception.expectMessage("For step 'bootstrap_node' syntax is illegal.");
         exception.expectMessage("Step input: 'input_with_sensitive_no_default' should have a String value, " +
@@ -163,8 +169,8 @@ public class PreCompileTransformersTest {
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource.toURI()));
 
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertTrue(errors.size() > 0);
+        assertNotNull(errors);
+        assertTrue(errors.size() > 0);
         exception.expect(RuntimeException.class);
         exception.expectMessage("For flow 'check_weather_flow_output_default_double' syntax is illegal.");
         exception.expectMessage("Output / publish value: 'flow_output_0' should have a String value, " +
@@ -177,16 +183,16 @@ public class PreCompileTransformersTest {
         URI resource = getClass().getResource("/corrupted/transformers/operation_output_wrong_property.sl").toURI();
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource));
 
-        Assert.assertNotNull(result);
+        assertNotNull(result);
 
         Executable executable = result.getExecutable();
-        Assert.assertNotNull(executable);
+        assertNotNull(executable);
         List<Output> outputs = executable.getOutputs();
-        Assert.assertEquals(2, outputs.size());
+        assertEquals(2, outputs.size());
 
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertTrue(errors.size() > 0);
+        assertNotNull(errors);
+        assertTrue(errors.size() > 0);
         exception.expect(RuntimeException.class);
         exception.expectMessage("For operation 'operation_output_wrong_property' syntax is illegal.");
         exception.expectMessage("Key: wrong_key in output: output_wrong_key is not a known property");
@@ -198,20 +204,45 @@ public class PreCompileTransformersTest {
         URI resource = getClass().getResource("/corrupted/transformers/operation_duplicate_result.sl").toURI();
         ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource));
 
-        Assert.assertNotNull(result);
+        assertNotNull(result);
 
         Executable executable = result.getExecutable();
-        Assert.assertNotNull(executable);
+        assertNotNull(executable);
         List<Result> results = executable.getResults();
-        Assert.assertEquals(2, results.size());
+        assertEquals(2, results.size());
 
         List<RuntimeException> errors = result.getErrors();
-        Assert.assertNotNull(errors);
-        Assert.assertTrue(errors.size() > 0);
+        assertNotNull(errors);
+        assertTrue(errors.size() > 0);
         exception.expect(RuntimeException.class);
         exception.expectMessage("For operation 'operation_duplicate_result' syntax is illegal.");
         exception.expectMessage("Duplicate result found: SUCCESS");
         throw errors.get(0);
+    }
+
+    @Test
+    public void testStepInputWithPrompt() throws URISyntaxException {
+        URI resource = getClass().getResource("/corrupted/transformers/check_flow_input_prompt.sl").toURI();
+        ExecutableModellingResult result = compiler.preCompileSource(SlangSource.fromFile(resource));
+
+        assertNotNull(result);
+
+        Executable executable = result.getExecutable();
+        assertNotNull(executable);
+
+        List<Input> inputs = executable.getInputs();
+
+        Input flowInput1 = inputs.get(0);
+        assertEquals(flowInput1.getPromptType(), PromptType.TEXT);
+        assertEquals(flowInput1.getPromptMessage(), "non-default-message");
+        assertEquals(flowInput1.getPromptOptions(), "opts");
+        assertEquals(flowInput1.getPromptDelimiter(), "|");
+
+        Input flowInput2 = inputs.get(1);
+        assertEquals(flowInput2.getPromptType(), PromptType.TEXT);
+        assertEquals(flowInput2.getPromptMessage(), "Enter a value for 'flow_input_2'");
+        assertNull(flowInput2.getPromptOptions());
+        assertEquals(flowInput2.getPromptDelimiter(), ",");
     }
 
 }

--- a/cloudslang-compiler/src/test/resources/corrupted/transformers/check_flow_input_prompt.sl
+++ b/cloudslang-compiler/src/test/resources/corrupted/transformers/check_flow_input_prompt.sl
@@ -24,6 +24,12 @@ flow:
     - flow_input_2:
         prompt:
           type: "text"
+    - flow_input_3:
+        prompt:
+          type: "single-choice"
+    - flow_input_4:
+        prompt:
+          type: "multi-choice"
   workflow:
     - bootstrap_node:
         do:

--- a/cloudslang-compiler/src/test/resources/corrupted/transformers/check_flow_input_prompt.sl
+++ b/cloudslang-compiler/src/test/resources/corrupted/transformers/check_flow_input_prompt.sl
@@ -1,0 +1,36 @@
+#   (c) Copyright 2014 Hewlett-Packard Development Company, L.P.
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Apache License v2.0 which accompany this distribution.
+#
+#   The Apache License is available at
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+namespace: user.flows
+
+imports:
+  ops: user.ops
+  flows: user.flows
+
+flow:
+  name: check_flow_input_prompt
+  inputs:
+    - flow_input_1:
+        default: "defaultValue"
+        prompt:
+          type: "text"
+          message: "non-default-message"
+          options: "opts"
+          delimiter: "|"
+    - flow_input_2:
+        prompt:
+          type: "text"
+  workflow:
+    - bootstrap_node:
+        do:
+          ops.check_flow_input_prompt:
+        navigate:
+          - FAILURE: on_failure
+          - SUCCESS: SUCCESS
+  results:
+    - FAILURE
+    - SUCCESS

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/PromptType.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/PromptType.java
@@ -12,7 +12,7 @@ package io.cloudslang.lang.entities;
 import java.util.Objects;
 
 public enum PromptType {
-    TEXT("text"), SINGLE_CHOICE("single_choice"), MULTI_CHOICE("multi_choice");
+    TEXT("text"), SINGLE_CHOICE("single-choice"), MULTI_CHOICE("multi-choice");
 
     private final String name;
 

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/PromptType.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/PromptType.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *******************************************************************************/
+package io.cloudslang.lang.entities;
+
+import java.util.Objects;
+
+public enum PromptType {
+    TEXT("text"), SINGLE_CHOICE("single_choice"), MULTI_CHOICE("multi_choice");
+
+    private final String name;
+
+    PromptType(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static PromptType fromString(String str) {
+        for (PromptType type : values()) {
+            if (Objects.equals(str, type.getName())) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Input.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/Input.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package io.cloudslang.lang.entities.bindings;
 
+import io.cloudslang.lang.entities.PromptType;
 import io.cloudslang.lang.entities.SensitivityLevel;
 import io.cloudslang.lang.entities.bindings.values.Value;
 import io.cloudslang.lang.entities.bindings.values.ValueFactory;
@@ -30,6 +31,10 @@ public class Input extends InOutParam {
 
     private boolean required;
     private boolean privateInput;
+    private PromptType promptType;
+    private String promptMessage;
+    private String promptOptions;
+    private String promptDelimiter;
 
     private Input(InputBuilder inputBuilder) {
         super(inputBuilder.name,
@@ -39,6 +44,10 @@ public class Input extends InOutParam {
         );
         this.required = inputBuilder.required;
         this.privateInput = inputBuilder.privateInput;
+        this.promptType = inputBuilder.promptType;
+        this.promptMessage = inputBuilder.promptMessage;
+        this.promptOptions = inputBuilder.promptOptions;
+        this.promptDelimiter = inputBuilder.promptDelimiter;
     }
 
     /**
@@ -56,12 +65,32 @@ public class Input extends InOutParam {
         return privateInput;
     }
 
+    public PromptType getPromptType() {
+        return promptType;
+    }
+
+    public String getPromptMessage() {
+        return promptMessage;
+    }
+
+    public String getPromptOptions() {
+        return promptOptions;
+    }
+
+    public String getPromptDelimiter() {
+        return promptDelimiter;
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .appendSuper(super.toString())
                 .append("required", required)
                 .append("privateInput", privateInput)
+                .append("promptType", promptType)
+                .append("promptMessage", promptMessage)
+                .append("promptOptions", promptOptions)
+                .append("promptDelimiter", promptDelimiter)
                 .toString();
     }
 
@@ -81,6 +110,10 @@ public class Input extends InOutParam {
                 .appendSuper(super.equals(o))
                 .append(required, input.required)
                 .append(privateInput, input.privateInput)
+                .append(promptType, input.promptType)
+                .append(promptMessage, input.promptMessage)
+                .append(promptOptions, input.promptOptions)
+                .append(promptDelimiter, input.promptDelimiter)
                 .isEquals();
     }
 
@@ -90,6 +123,10 @@ public class Input extends InOutParam {
                 .appendSuper(super.hashCode())
                 .append(required)
                 .append(privateInput)
+                .append(promptType)
+                .append(promptMessage)
+                .append(promptOptions)
+                .append(promptDelimiter)
                 .toHashCode();
     }
 
@@ -100,6 +137,10 @@ public class Input extends InOutParam {
         private boolean privateInput;
         private Set<ScriptFunction> functionDependencies;
         private Set<String> systemPropertyDependencies;
+        private PromptType promptType;
+        private String promptMessage;
+        private String promptOptions;
+        private String promptDelimiter;
 
         public InputBuilder(String name, Serializable serializable) {
             this(name, serializable, false);
@@ -150,6 +191,26 @@ public class Input extends InOutParam {
 
         public InputBuilder withSystemPropertyDependencies(Set<String> systemPropertyDependencies) {
             this.systemPropertyDependencies = systemPropertyDependencies;
+            return this;
+        }
+
+        public InputBuilder withPrompt(PromptType promptType) {
+            this.promptType = promptType;
+            return this;
+        }
+
+        public InputBuilder withPromptMessage(String promptMessage) {
+            this.promptMessage = promptMessage;
+            return this;
+        }
+
+        public InputBuilder withPromptOptions(String promptOptions) {
+            this.promptOptions = promptOptions;
+            return this;
+        }
+
+        public InputBuilder withPromptDelimiter(String promptDelimiter) {
+            this.promptDelimiter = promptDelimiter;
             return this;
         }
 

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -34,6 +34,8 @@ import org.apache.commons.lang.Validate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import static java.util.Objects.nonNull;
+
 @Component
 public class InputsBinding extends AbstractBinding {
 
@@ -75,7 +77,7 @@ public class InputsBinding extends AbstractBinding {
             throw new RuntimeException(errorMessagePrefix + "', \n\t" + t.getMessage(), t);
         }
 
-        if (input.isRequired() && isEmpty(value)) {
+        if (input.isRequired() && isEmpty(value) || nonNull(input.getPromptType())) {
             missingInputs.add(input);
             return;
         }


### PR DESCRIPTION
Language change
Input definition may contain prompt settings to be later used by custom missing input handlers.
For example

```
inputs:
    - flow_input_1:
        default: "defaultValue"
        prompt:
          type: "text"
          message: "non-default-message"
          options: "opts"
          delimiter: "|"
    - flow_input_2:
        prompt:
          type: "text"
    - flow_input_3:
        prompt:
          type: "single-choice"
    - flow_input_4:
        prompt:
          type: "multi-choice"
```

Signed-off-by: Vitalii Shevchuk vitalii.shevchuk@microfocus.com 