### PR TITLE
Added 'use empty value for prompts' flag

### DIFF
--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ScoreLangConstants.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/ScoreLangConstants.java
@@ -100,4 +100,5 @@ public interface ScoreLangConstants {
 
     //prompting
     String PROMPTED_USER_INPUTS_KEY = "PROMPTED_USER_INPUTS_KEY";
+    String USE_EMPTY_VALUES_FOR_PROMPTS_KEY = "useEmptyValuesForPrompts";
 }

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -80,7 +80,12 @@ public class InputsBinding extends AbstractBinding {
             throw new RuntimeException(errorMessagePrefix + "', \n\t" + t.getMessage(), t);
         }
 
-        if (input.isRequired() && isEmpty(value) || nonNull(input.getPromptType())) {
+        if (input.isRequired() && isEmpty(value)) {
+            missingInputs.add(input);
+            return;
+        }
+
+        if (nonNull(input.getPromptType())) {
             if (useEmptyValuesForPrompts) {
                 value = ValueFactory.create(EMPTY, input.isSensitive());
             } else {

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static java.util.Objects.nonNull;
+import static org.apache.commons.lang.StringUtils.EMPTY;
 
 @Component
 public class InputsBinding extends AbstractBinding {
@@ -50,21 +51,23 @@ public class InputsBinding extends AbstractBinding {
      * @return : a new map with all inputs resolved (does not include initial context)
      */
     public Map<String, Value> bindInputs(List<Input> inputs, Map<String, ? extends Value> context,
-                                         Set<SystemProperty> systemProperties, List<Input> missingInputs) {
+                                         Set<SystemProperty> systemProperties, List<Input> missingInputs,
+                                         boolean useEmptyValuesForPrompts) {
         Map<String, Value> resultContext = new LinkedHashMap<>();
 
         //we do not want to change original context map
         Map<String, Value> srcContext = new LinkedHashMap<>(context);
 
         for (Input input : inputs) {
-            bindInput(input, srcContext, resultContext, systemProperties, missingInputs);
+            bindInput(input, srcContext, resultContext, systemProperties, missingInputs, useEmptyValuesForPrompts);
         }
 
         return resultContext;
     }
 
     private void bindInput(Input input, Map<String, ? extends Value> context, Map<String, Value> targetContext,
-                            Set<SystemProperty> systemProperties, List<Input> missingInputs) {
+                           Set<SystemProperty> systemProperties, List<Input> missingInputs,
+                           boolean useEmptyValuesForPrompts) {
         Value value;
 
         String inputName = input.getName();
@@ -78,8 +81,12 @@ public class InputsBinding extends AbstractBinding {
         }
 
         if (input.isRequired() && isEmpty(value) || nonNull(input.getPromptType())) {
-            missingInputs.add(input);
-            return;
+            if (useEmptyValuesForPrompts) {
+                value = ValueFactory.create(EMPTY, input.isSensitive());
+            } else {
+                missingInputs.add(input);
+                return;
+            }
         }
 
         validateStringValue(errorMessagePrefix, value);

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/strategies/EnforceValueMissingInputHandler.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/strategies/EnforceValueMissingInputHandler.java
@@ -32,7 +32,8 @@ public class EnforceValueMissingInputHandler implements MissingInputHandler {
                                         RunEnvironment runEnv,
                                         ExecutionRuntimeServices runtimeServices,
                                         LanguageEventData.StepType stepType,
-                                        String stepName) {
+                                        String stepName,
+                                        boolean emptyValuesForPrompts) {
         if (CollectionUtils.isNotEmpty(missingInputs)) {
             String exceptionMessage = missingInputs
                     .stream()

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/strategies/MissingInputHandler.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/strategies/MissingInputHandler.java
@@ -25,12 +25,13 @@ import java.util.Map;
 public interface MissingInputHandler {
 
     /**
-     * @param missingInputs     the list of inputs for
-     * @param systemContext     the system context
-     * @param runEnv            the run environment
-     * @param runtimeServices   the runtime services
-     * @param stepType          the step type
-     * @param stepName          the step name
+     * @param missingInputs           the list of inputs for
+     * @param systemContext           the system context
+     * @param runEnv                  the run environment
+     * @param runtimeServices         the runtime services
+     * @param stepType                the step type
+     * @param stepName                the step name
+     * @param emptyValuesForPrompts   the flag to force empty value for prompts
      * @return                  boolean flag to indicate if engine can continue
      */
     boolean resolveMissingInputs(List<Input> missingInputs,
@@ -38,7 +39,8 @@ public interface MissingInputHandler {
                                  RunEnvironment runEnv,
                                  ExecutionRuntimeServices runtimeServices,
                                  StepType stepType,
-                                 String stepName);
+                                 String stepName,
+                                 boolean emptyValuesForPrompts);
 
     /**
      * @param systemContext the system context

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -47,7 +47,7 @@ import static io.cloudslang.score.api.execution.ExecutionParametersConsts.EXECUT
 import static io.cloudslang.score.api.execution.ExecutionParametersConsts.SYSTEM_CONTEXT;
 import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.toMap;
-import static org.apache.commons.lang.BooleanUtils.isTrue;
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -42,10 +42,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static io.cloudslang.lang.entities.ScoreLangConstants.USE_EMPTY_VALUES_FOR_PROMPTS_KEY;
 import static io.cloudslang.score.api.execution.ExecutionParametersConsts.EXECUTION_RUNTIME_SERVICES;
 import static io.cloudslang.score.api.execution.ExecutionParametersConsts.SYSTEM_CONTEXT;
 import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.lang.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
@@ -87,7 +89,8 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                                 @Param(ScoreLangConstants.NODE_NAME_KEY) String nodeName,
                                 @Param(ScoreLangConstants.NEXT_STEP_ID_KEY) Long nextStepId,
                                 @Param(ScoreLangConstants.EXECUTABLE_TYPE) ExecutableType executableType,
-                                @Param(SYSTEM_CONTEXT) SystemContext systemContext) {
+                                @Param(SYSTEM_CONTEXT) SystemContext systemContext,
+                                @Param(USE_EMPTY_VALUES_FOR_PROMPTS_KEY) Boolean useEmptyValuesForPrompts) {
         try {
             Map<String, Value> callArguments = runEnv.removeCallArguments();
 
@@ -127,8 +130,12 @@ public class ExecutableExecutionData extends AbstractExecutionData {
             );
 
             List<Input> missingInputs = new ArrayList<>();
-            Map<String, Value> boundInputValues = inputsBinding
-                    .bindInputs(executableInputs, callArguments, runEnv.getSystemProperties(), missingInputs);
+            Map<String, Value> boundInputValues = inputsBinding.bindInputs(
+                    executableInputs,
+                    callArguments,
+                    runEnv.getSystemProperties(),
+                    missingInputs,
+                    isTrue(useEmptyValuesForPrompts));
 
             //if there are any missing required input after binding
             // try to resolve it using provided missing input handler
@@ -139,7 +146,8 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                         runEnv,
                         executionRuntimeServices,
                         stepType,
-                        nodeName);
+                        nodeName,
+                        isTrue(useEmptyValuesForPrompts));
 
                 if (!canContinue) {
                     return;

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/InputsBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/InputsBindingTest.java
@@ -459,7 +459,7 @@ public class InputsBindingTest {
 
     private Map<String, Value> bindInputs(List<Input> inputs, Map<String, Value> context,
                                           Set<SystemProperty> systemProperties, List<Input> missingInputs) {
-        return inputsBinding.bindInputs(inputs, context, systemProperties, missingInputs);
+        return inputsBinding.bindInputs(inputs, context, systemProperties, missingInputs, false);
     }
 
     private Map<String, Value> bindInputs(List<Input> inputs, Map<String, Value> context) {

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
@@ -65,6 +65,7 @@ import java.util.Set;
 import java.util.concurrent.Semaphore;
 
 import static java.util.Collections.singletonList;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyMapOf;
@@ -97,7 +98,7 @@ public class ExecutableStepsTest {
     public void testStart() throws Exception {
         executableSteps.startExecutable(new ArrayList<Input>(), new RunEnvironment(),
             new HashMap<String, Value>(), new ExecutionRuntimeServices(), "", 2L, ExecutableType.FLOW,
-                new SystemContext());
+                new SystemContext(), false);
     }
 
     @Test
@@ -108,9 +109,9 @@ public class ExecutableStepsTest {
         Map<String, Value> resultMap = new HashMap<>();
         resultMap.put("input1", ValueFactory.create(5));
 
-        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anySet(), anyList())).thenReturn(resultMap);
+        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anySet(), anyList(), anyBoolean())).thenReturn(resultMap);
         executableSteps.startExecutable(inputs, runEnv, new HashMap<String, Value>(),
-            new ExecutionRuntimeServices(), "", 2L, ExecutableType.FLOW, new SystemContext());
+            new ExecutionRuntimeServices(), "", 2L, ExecutableType.FLOW, new SystemContext(), false);
 
         Map<String, Value> opVars = runEnv.getStack().popContext().getImmutableViewOfVariables();
         Assert.assertTrue(opVars.containsKey("input1"));
@@ -137,9 +138,9 @@ public class ExecutableStepsTest {
         resultMap.put("input1", ValueFactory.create(inputs.get(0).getValue()));
         resultMap.put("input2", ValueFactory.create(inputs.get(1).getValue()));
 
-        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anySet(), anyList())).thenReturn(resultMap);
+        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anySet(), anyList(), anyBoolean())).thenReturn(resultMap);
         executableSteps.startExecutable(inputs, runEnv, new HashMap<String, Value>(),
-            runtimeServices, "dockerizeStep", 2L, ExecutableType.FLOW, new SystemContext());
+            runtimeServices, "dockerizeStep", 2L, ExecutableType.FLOW, new SystemContext(), false);
         Collection<ScoreEvent> events = runtimeServices.getEvents();
 
         Assert.assertFalse(events.isEmpty());
@@ -186,7 +187,7 @@ public class ExecutableStepsTest {
         Long nextStepPosition = 2L;
         executableSteps.startExecutable(inputs, runEnv, new HashMap<String, Value>(),
                 new ExecutionRuntimeServices(), "", nextStepPosition, ExecutableType.FLOW,
-                new SystemContext());
+                new SystemContext(), false);
 
         Assert.assertEquals(nextStepPosition, runEnv.removeNextStepPosition());
     }


### PR DESCRIPTION
Added new flag 'useEmptyValuesForPrompts' that will substitute empty string for prompt inputs 

Signed-off-by: Vitalii Shevchuk vitalii.shevchuk@microfocus.com