### PR TITLE
list_iterator_fix

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
@@ -15,6 +15,7 @@ import com.hp.oo.sdk.content.plugin.SerializableSessionObject;
 import com.hp.oo.sdk.content.plugin.SessionObject;
 import com.hp.oo.sdk.content.plugin.StepSerializableSessionObject;
 import io.cloudslang.runtime.api.java.JavaExecutionParametersProvider;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -147,10 +148,8 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
     private void handleSessionContextArgument(Map sessionData, String objectClassName, List<Object> args,
                                               String parameterName, ClassLoader classLoader) {
         // cloudslang list iterator fix
-        String parameter = parameterName;
-        if (this.nodeNameWithDepth != null) {
-            parameter = this.nodeNameWithDepth.startsWith("list_iterator") ? this.nodeNameWithDepth : parameterName;
-        }
+        final String parameter = StringUtils.startsWith(this.nodeNameWithDepth, "list_iterator") ?
+                                                   this.nodeNameWithDepth : parameterName;
 
         Object sessionContextObject = sessionData.get(parameter);
         if (sessionContextObject == null) {

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
@@ -146,7 +146,11 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
 
     private void handleSessionContextArgument(Map sessionData, String objectClassName, List<Object> args,
                                               String parameterName, ClassLoader classLoader) {
-        Object sessionContextObject = sessionData.get(parameterName);
+        // cloudslang list iterator fix
+        final String parameter = this.nodeNameWithDepth.startsWith("list_iterator") ?
+                                                     this.nodeNameWithDepth : parameterName ;
+
+        Object sessionContextObject = sessionData.get(parameter);
         if (sessionContextObject == null) {
             try {
                 sessionContextObject = Class.forName(objectClassName, true, classLoader).newInstance();
@@ -154,7 +158,7 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
                 throw new RuntimeException("Failed to create instance of [" + objectClassName + "] class", e);
             }
             //noinspection unchecked
-            sessionData.put(parameterName, sessionContextObject);
+            sessionData.put(parameter, sessionContextObject);
         }
         args.add(sessionContextObject);
     }

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/CloudSlangJavaExecutionParameterProvider.java
@@ -147,8 +147,10 @@ public class CloudSlangJavaExecutionParameterProvider implements JavaExecutionPa
     private void handleSessionContextArgument(Map sessionData, String objectClassName, List<Object> args,
                                               String parameterName, ClassLoader classLoader) {
         // cloudslang list iterator fix
-        final String parameter = this.nodeNameWithDepth.startsWith("list_iterator") ?
-                                                     this.nodeNameWithDepth : parameterName ;
+        String parameter = parameterName;
+        if (this.nodeNameWithDepth != null) {
+            parameter = this.nodeNameWithDepth.startsWith("list_iterator") ? this.nodeNameWithDepth : parameterName;
+        }
 
         Object sessionContextObject = sessionData.get(parameter);
         if (sessionContextObject == null) {


### PR DESCRIPTION
In case of nested iterators, context is not being passed correctly in the cloudslang. I changed the way how the context is passed to cloudslang content to fix the iterator issue.

Existing Behaviour : In nested scenario same context is being passed to all the iteraors and causing the nested iterators to run forever.
Modified Behaviour: One context object for each iterator in nested scenario.

Signed-off-by: Mallikarjuna mallikarjunareddy.tipparreddy@microfocus.com