### PR TITLE
fixing Oracle case with null in SystemProperties

### DIFF
--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/PlainPyObjectValue.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/PlainPyObjectValue.java
@@ -41,6 +41,6 @@ public class PlainPyObjectValue implements PyObjectValue {
 
     @Override
     public String toString() {
-        return String.valueOf(value);
+        return value == null ? "" : value.toString();
     }
 }

--- a/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/Value.java
+++ b/cloudslang-entities/src/main/java/io/cloudslang/lang/entities/bindings/values/Value.java
@@ -34,4 +34,9 @@ public interface Value extends Serializable {
     static String toStringSafe(Value value) {
         return value != null && value.get() != null ? value.toString() : null;
     }
+
+    static String toStringSafeEmpty(Value value) {
+        return value != null && value.get() != null ? value.toString() : "";
+    }
+
 }

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ArgumentsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ArgumentsBinding.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static io.cloudslang.lang.entities.utils.ExpressionUtils.extractExpression;
@@ -107,9 +106,7 @@ public class ArgumentsBinding extends AbstractBinding {
                             systemProperties,
                             argument.getFunctionDependencies());
 
-                    Optional.ofNullable(result)
-                            .map(Value::toStringSafe)
-                            .ifPresent(prompt::setPromptMessage);
+                    prompt.setPromptMessage(Value.toStringSafeEmpty(result));
                 }
             }
 

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ArgumentsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ArgumentsBinding.java
@@ -22,10 +22,10 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static io.cloudslang.lang.entities.utils.ExpressionUtils.extractExpression;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 /**
  * @author Bonczidai Levente
@@ -107,12 +107,9 @@ public class ArgumentsBinding extends AbstractBinding {
                             systemProperties,
                             argument.getFunctionDependencies());
 
-                    String resultString = Value.toStringSafe(result);
-                    if (resultString == null) {
-                        prompt.setPromptMessage(EMPTY);
-                    } else {
-                        prompt.setPromptMessage(resultString);
-                    }
+                    Optional.ofNullable(result)
+                            .map(Value::toStringSafe)
+                            .ifPresent(prompt::setPromptMessage);
                 }
             }
 

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ArgumentsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/ArgumentsBinding.java
@@ -22,10 +22,10 @@ import org.springframework.stereotype.Component;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static io.cloudslang.lang.entities.utils.ExpressionUtils.extractExpression;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 /**
  * @author Bonczidai Levente
@@ -107,9 +107,12 @@ public class ArgumentsBinding extends AbstractBinding {
                             systemProperties,
                             argument.getFunctionDependencies());
 
-                    Optional.ofNullable(result)
-                            .map(Value::toStringSafe)
-                            .ifPresent(prompt::setPromptMessage);
+                    String resultString = Value.toStringSafe(result);
+                    if (resultString == null) {
+                        prompt.setPromptMessage(EMPTY);
+                    } else {
+                        prompt.setPromptMessage(resultString);
+                    }
                 }
             }
 

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -30,7 +30,6 @@ import io.cloudslang.lang.runtime.bindings.scripts.ScriptEvaluator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.LinkedHashMap;
 import org.apache.commons.lang.Validate;
@@ -146,9 +145,13 @@ public class InputsBinding extends AbstractBinding {
                         systemProperties,
                         input.getFunctionDependencies());
 
-                Optional.ofNullable(result)
-                        .map(Value::toStringSafe)
-                        .ifPresent(prompt::setPromptMessage);
+                String resultString = Value.toStringSafe(result);
+                if (resultString == null) {
+                    prompt.setPromptMessage(EMPTY);
+                } else {
+                    prompt.setPromptMessage(resultString);
+                }
+
             }
         }
 

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -30,6 +30,7 @@ import io.cloudslang.lang.runtime.bindings.scripts.ScriptEvaluator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.LinkedHashMap;
 import org.apache.commons.lang.Validate;
@@ -145,13 +146,9 @@ public class InputsBinding extends AbstractBinding {
                         systemProperties,
                         input.getFunctionDependencies());
 
-                String resultString = Value.toStringSafe(result);
-                if (resultString == null) {
-                    prompt.setPromptMessage(EMPTY);
-                } else {
-                    prompt.setPromptMessage(resultString);
-                }
-
+                Optional.ofNullable(result)
+                        .map(Value::toStringSafe)
+                        .ifPresent(prompt::setPromptMessage);
             }
         }
 

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -30,7 +30,6 @@ import io.cloudslang.lang.runtime.bindings.scripts.ScriptEvaluator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.LinkedHashMap;
 import org.apache.commons.lang.Validate;
@@ -146,9 +145,8 @@ public class InputsBinding extends AbstractBinding {
                         systemProperties,
                         input.getFunctionDependencies());
 
-                Optional.ofNullable(result)
-                        .map(Value::toStringSafe)
-                        .ifPresent(prompt::setPromptMessage);
+                prompt.setPromptMessage(Value.toStringSafeEmpty(result));
+
             }
         }
 


### PR DESCRIPTION
There is a valid case when python expression may return null for Prompt Message. For example Oracle case with empty System Properties. Before fix promptMessage was not changed for null case and it will cause to evaluate expression on each step and failed in case where there is no functional dependency. The idea is to set Prompt Message to EMPTY if expression successfully evaluated and return null.

Signed-off-by: Mikhail Mishustin mikhail.mishustin@microfocus.com