### PR TITLE
Added prompt handling for additional inputs

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -170,12 +170,10 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                 }
             }
 
-            Map<String, Value> actionArguments = new HashMap<>();
-
-            actionArguments.putAll(boundInputValues);
+            Map<String, Value> actionArguments = new HashMap<>(boundInputValues);
 
             //updated stored input arguments to be later used for output binding
-            updateStoredStepArguments(runEnv, promptedValues);
+            saveStepInputsResultContext(runEnv, callArguments, promptedValues);
 
             //done with the user inputs, don't want it to be available in next startExecutable steps..
             if (userInputs != null) {
@@ -382,12 +380,14 @@ public class ExecutableExecutionData extends AbstractExecutionData {
 
     }
 
-    public void updateStoredStepArguments(RunEnvironment runEnv, Map<String, Value> promptedValues) {
-        Context context = runEnv.getStack().peekContext();
-        if (context != null) {
-            Map<String, Value> originalStepArguments = removeStepInputsResultContext(context);
-            originalStepArguments.putAll(promptedValues);
-            saveStepInputsResultContext(context, originalStepArguments);
+    public void saveStepInputsResultContext(RunEnvironment runEnv,
+                                            Map<String, Value> originalCallArguments,
+                                            Map<String, Value> promptedValues) {
+        Context flowContext = runEnv.getStack().peekContext();
+        if (flowContext != null) {
+            Map<String, Value> finalActionArguments = new HashMap<>(originalCallArguments);
+            finalActionArguments.putAll(promptedValues);
+            saveStepInputsResultContext(flowContext, finalActionArguments);
         }
     }
 

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package io.cloudslang.lang.runtime.steps;
 
+import com.google.common.collect.Sets;
 import com.hp.oo.sdk.content.annotations.Param;
 import io.cloudslang.lang.entities.ExecutableType;
 import io.cloudslang.lang.entities.ScoreLangConstants;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static io.cloudslang.lang.entities.ScoreLangConstants.USE_EMPTY_VALUES_FOR_PROMPTS_KEY;
@@ -48,7 +50,9 @@ import static io.cloudslang.lang.entities.bindings.values.Value.toStringSafe;
 import static io.cloudslang.score.api.execution.ExecutionParametersConsts.EXECUTION_RUNTIME_SERVICES;
 import static io.cloudslang.score.api.execution.ExecutionParametersConsts.SYSTEM_CONTEXT;
 import static java.lang.String.valueOf;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
@@ -121,6 +125,8 @@ public class ExecutableExecutionData extends AbstractExecutionData {
 
             Map<String, Prompt> promptArguments = runEnv.removePromptArguments();
 
+            executableInputs.addAll(extractUserDefinedStepInputs(executableInputs, promptArguments, callArguments));
+
             LanguageEventData.StepType stepType = LanguageEventData.convertExecutableType(executableType);
             sendStartBindingInputsEvent(
                     executableInputs,
@@ -167,6 +173,9 @@ public class ExecutableExecutionData extends AbstractExecutionData {
             Map<String, Value> actionArguments = new HashMap<>();
 
             actionArguments.putAll(boundInputValues);
+
+            //updated stored input arguments to be later used for output binding
+            updateStoredStepArguments(runEnv, promptedValues);
 
             //done with the user inputs, don't want it to be available in next startExecutable steps..
             if (userInputs != null) {
@@ -352,6 +361,34 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                 throw new RuntimeException("Unrecognized type: " + executableType);
         }
         return returnValues;
+    }
+
+    private List<Input> extractUserDefinedStepInputs(List<Input> inputs,
+                                              Map<String, Prompt> prompts,
+                                              Map<String, Value> callArguments) {
+        Set<String> inputNames = inputs.stream().map(Input::getName).collect(toSet());
+        Set<String> promptInputNames = prompts.keySet();
+
+        return Sets
+                .difference(promptInputNames, inputNames)
+                .stream()
+                .map(additionalInputName ->
+                        new Input
+                                .InputBuilder(additionalInputName, callArguments.get(additionalInputName))
+                                .withPrompt(prompts.get(additionalInputName))
+                                .build()
+                )
+                .collect(toList());
+
+    }
+
+    public void updateStoredStepArguments(RunEnvironment runEnv, Map<String, Value> promptedValues) {
+        Context context = runEnv.getStack().peekContext();
+        if (context != null) {
+            Map<String, Value> originalStepArguments = removeStepInputsResultContext(context);
+            originalStepArguments.putAll(promptedValues);
+            saveStepInputsResultContext(context, originalStepArguments);
+        }
     }
 
 }

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/StepExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/StepExecutionData.java
@@ -133,7 +133,6 @@ public class StepExecutionData extends AbstractExecutionData {
             Map<String, Value> boundInputs = argumentsBinding
                     .bindArguments(stepInputs, contextAccessor,
                             runEnv.getSystemProperties());
-            saveStepInputsResultContext(flowContext, boundInputs);
 
             sendEndBindingArgumentsEvent(
                     stepInputs,


### PR DESCRIPTION
Added prompts for additional inputs(the ones not present in operation definition)
Moved arguments save logic to ExecutableExecutionData, cause user might changed value originally provided to StepExecutionData

Signed-off by: Vitalii Shevchuk vitalii.shevchuk@microfocus.com