### PR TITLE
1040294 sheduler added inputs not working fix

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -98,12 +98,13 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                                 @Param(USE_EMPTY_VALUES_FOR_PROMPTS_KEY) Boolean useEmptyValuesForPrompts) {
         try {
             Map<String, Value> callArguments = runEnv.removeCallArguments();
+            List<Input> mutableInputList = new ArrayList<>(executableInputs);
 
             if (userInputs != null) {
                 callArguments.putAll(userInputs);
                 // merge is done only for flows that have extra inputs besides those defined as "flow inputs"
                 if (executionRuntimeServices.getMergeUserInputs()) {
-                    Map<String, Input> executableInputsMap = executableInputs.stream()
+                    Map<String, Input> executableInputsMap = mutableInputList.stream()
                             .collect(toMap(Input::getName, Function.identity()));
                     for (String inputName : userInputs.keySet()) {
                         Value inputValue = userInputs.get(inputName);
@@ -111,17 +112,15 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                         if (inputToUpdate != null) {
                             Input updatedInput = new Input.InputBuilder(inputToUpdate, inputValue)
                                     .build();
-                            executableInputs = updateExecutableInputs(executableInputs,
-                                    executableInputs.indexOf(inputToUpdate),
-                                    updatedInput);
+                            mutableInputList.set(mutableInputList.indexOf(inputToUpdate), updatedInput);
                         } else {
                             Input toAddInput = new Input.InputBuilder(inputName, inputValue).build();
-                            executableInputs.add(toAddInput);
+                            mutableInputList.add(toAddInput);
                         }
                     }
                 }
             }
-
+            executableInputs = Collections.unmodifiableList(mutableInputList);
             //restore what was already prompted and add newly prompted values
             Map<String, Value> promptedValues = runEnv.removePromptedValues();
             promptedValues.putAll(missingInputHandler.applyPromptInputValues(systemContext, executableInputs));
@@ -411,11 +410,4 @@ public class ExecutableExecutionData extends AbstractExecutionData {
             saveStepInputsResultContext(flowContext, finalActionArguments);
         }
     }
-
-    private List<Input> updateExecutableInputs(List<Input> executableInputs, int updateIndex, Input updatedInput) {
-        List<Input> updatedExecutableInputsList = new ArrayList<>(executableInputs);
-        updatedExecutableInputsList.set(updateIndex, updatedInput);
-        return Collections.unmodifiableList(updatedExecutableInputsList);
-    }
-
 }

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -111,7 +111,9 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                         if (inputToUpdate != null) {
                             Input updatedInput = new Input.InputBuilder(inputToUpdate, inputValue)
                                     .build();
-                            executableInputs.set(executableInputs.indexOf(inputToUpdate), updatedInput);
+                            executableInputs = updateExecutableInputs(executableInputs,
+                                    executableInputs.indexOf(inputToUpdate),
+                                    updatedInput);
                         } else {
                             Input toAddInput = new Input.InputBuilder(inputName, inputValue).build();
                             executableInputs.add(toAddInput);
@@ -381,8 +383,8 @@ public class ExecutableExecutionData extends AbstractExecutionData {
     }
 
     private List<Input> extractUserDefinedStepInputs(List<Input> inputs,
-                                              Map<String, Prompt> prompts,
-                                              Map<String, Value> callArguments) {
+                                                     Map<String, Prompt> prompts,
+                                                     Map<String, Value> callArguments) {
         Set<String> inputNames = inputs.stream().map(Input::getName).collect(toCollection(LinkedHashSet::new));
         Set<String> promptInputNames = prompts.keySet();
 
@@ -408,6 +410,12 @@ public class ExecutableExecutionData extends AbstractExecutionData {
             finalActionArguments.putAll(promptedValues);
             saveStepInputsResultContext(flowContext, finalActionArguments);
         }
+    }
+
+    private List<Input> updateExecutableInputs(List<Input> executableInputs, int updateIndex, Input updatedInput) {
+        List<Input> updatedExecutableInputsList = new ArrayList<>(executableInputs);
+        updatedExecutableInputsList.set(updateIndex, updatedInput);
+        return Collections.unmodifiableList(updatedExecutableInputsList);
     }
 
 }


### PR DESCRIPTION
Added method for creating a new unmodifiable list when updating the input list

Signed-off-by: Alexandra Ilas alexandra.ilas@microfocus.com 