### PR TITLE
Changed option behavior `use empty value for prompts`

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -102,7 +102,7 @@ public class InputsBinding extends AbstractBinding {
             }
 
             if (input.hasPrompt()) {
-                if (useEmptyValuesForPrompts) {
+                if (useEmptyValuesForPrompts && isNull(value)) {
                     value = createEmptyValue(input);
                 } else if (isNull(promptValue)) {
                     resolvePromptExpressions(input, context, targetContext, systemProperties);


### PR DESCRIPTION
...it will try to use value from ctx first

Signed-off by: Vitalii Shevchuk vitalii.shevchuk@microfocus.com