### PR TITLE
Use empty values for prompts shouldn't pause execution

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -102,9 +102,11 @@ public class InputsBinding extends AbstractBinding {
             }
 
             if (input.hasPrompt()) {
-                if (useEmptyValuesForPrompts && isNull(value)) {
-                    value = createEmptyValue(input);
-                } else if (isNull(promptValue)) {
+                if (useEmptyValuesForPrompts) {
+                    if (isNull(value)) {
+                        value = createEmptyValue(input);
+                    }
+                } else {
                     resolvePromptExpressions(input, context, targetContext, systemProperties);
 
                     missingInputs.add(createMissingInput(input, value));


### PR DESCRIPTION
Signed-off by: Vitalii Shevchuk vitalii.shevchuk@microfocus.com