### PR TITLE
import re for jython

### DIFF
--- a/cloudslang-runtime/src/main/resources/scripts/cs_extract_number.py
+++ b/cloudslang-runtime/src/main/resources/scripts/cs_extract_number.py
@@ -1,4 +1,5 @@
 def cs_extract_number(string, count = 1):
+  import re
   if type(string).__name__ != 'str' and type(string).__name__ != 'unicode':
     raise Exception("Expected a string for parameter 'string', got " + str(string))
 

--- a/cloudslang-runtime/src/main/resources/scripts/cs_extract_number.py
+++ b/cloudslang-runtime/src/main/resources/scripts/cs_extract_number.py
@@ -1,5 +1,5 @@
+import re
 def cs_extract_number(string, count = 1):
-  import re
   if type(string).__name__ != 'str' and type(string).__name__ != 'unicode':
     raise Exception("Expected a string for parameter 'string', got " + str(string))
 


### PR DESCRIPTION
import module regular expressions because it's used for findall operation in script
Signed-off-by: Larisa Bratean <larisa-alexandra.bratean@microfocus.com>