### PR TITLE
added a flag to switch between jython and python in conf file of CLI & builder. Upated the version of cloudslang

### DIFF
--- a/cloudslang-all/pom.xml
+++ b/cloudslang-all/pom.xml
@@ -11,7 +11,7 @@ http://www.apache.org/licenses/LICENSE-2.0
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cloudslang-api-commons/pom.xml
+++ b/cloudslang-api-commons/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cloudslang-cli/pom.xml
+++ b/cloudslang-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cloudslang-cli</artifactId>

--- a/cloudslang-cli/pom.xml
+++ b/cloudslang-cli/pom.xml
@@ -16,8 +16,6 @@
         <cs-content.revision>master</cs-content.revision>
         <cs-content.type>branch</cs-content.type>
         <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
-        <python>3.8.7.0</python>
-        <python.path>@BASEDIR@/python-lib/python-3.8.7</python.path>
     </properties>
 
     <dependencies>
@@ -259,7 +257,6 @@
                             <id>cslang</id>
                         </program>
                     </programs>
-                    <extraJvmArguments>-Dpython.path=${python.path}</extraJvmArguments>
                 </configuration>
             </plugin>
             <plugin>
@@ -283,15 +280,6 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${basedir}/target/cslang-cli/maven</outputDirectory>
                                     <destFileName>maven</destFileName>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.microfocus.itom.oo</groupId>
-                                    <artifactId>python</artifactId>
-                                    <version>${python}</version>
-                                    <classifier>win</classifier>
-                                    <type>zip</type>
-                                    <outputDirectory>${basedir}/target/cslang-cli/python-lib</outputDirectory>
-                                    <destFileName>python-lib</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/cloudslang-cli/pom.xml
+++ b/cloudslang-cli/pom.xml
@@ -16,6 +16,8 @@
         <cs-content.revision>master</cs-content.revision>
         <cs-content.type>branch</cs-content.type>
         <assembly.tarLongFileMode>posix</assembly.tarLongFileMode>
+        <python>3.8.7.0</python>
+        <python.path>@BASEDIR@/python-lib/python-3.8.7</python.path>
     </properties>
 
     <dependencies>
@@ -251,7 +253,7 @@
                             <id>cslang</id>
                         </program>
                     </programs>
-                    <extraJvmArguments>-Dpython.path=@BASEDIR@/python-lib</extraJvmArguments>
+                    <extraJvmArguments>-Dpython.path=${python.path}</extraJvmArguments>
                 </configuration>
             </plugin>
             <plugin>
@@ -275,6 +277,15 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${basedir}/target/cslang-cli/maven</outputDirectory>
                                     <destFileName>maven</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.microfocus.itom.oo</groupId>
+                                    <artifactId>python</artifactId>
+                                    <version>${python}</version>
+                                    <classifier>win</classifier>
+                                    <type>zip</type>
+                                    <outputDirectory>${basedir}/target/cslang-cli/python-lib</outputDirectory>
+                                    <destFileName>python-lib</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/cloudslang-cli/src/main/resources/configuration/cslang.properties
+++ b/cloudslang-cli/src/main/resources/configuration/cslang.properties
@@ -8,3 +8,4 @@ maven.m2.conf.path=${app.home}/maven/conf/m2.conf
 cloudslang.maven.repo.local=${app.home}/maven/repo
 cloudslang.maven.repo.remote.url=http://repo1.maven.org/maven2
 cloudslang.maven.plugins.remote.url=http://repo1.maven.org/maven2
+use.jython.expressions=false

--- a/cloudslang-cli/src/main/resources/configuration/cslang.properties
+++ b/cloudslang-cli/src/main/resources/configuration/cslang.properties
@@ -9,3 +9,4 @@ cloudslang.maven.repo.local=${app.home}/maven/repo
 cloudslang.maven.repo.remote.url=http://repo1.maven.org/maven2
 cloudslang.maven.plugins.remote.url=http://repo1.maven.org/maven2
 use.jython.expressions=true
+#python.path=provide the python 3.8.7 path here

--- a/cloudslang-cli/src/main/resources/configuration/cslang.properties
+++ b/cloudslang-cli/src/main/resources/configuration/cslang.properties
@@ -8,4 +8,4 @@ maven.m2.conf.path=${app.home}/maven/conf/m2.conf
 cloudslang.maven.repo.local=${app.home}/maven/repo
 cloudslang.maven.repo.remote.url=http://repo1.maven.org/maven2
 cloudslang.maven.plugins.remote.url=http://repo1.maven.org/maven2
-use.jython.expressions=false
+use.jython.expressions=true

--- a/cloudslang-commons/pom.xml
+++ b/cloudslang-commons/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cloudslang-compiler/pom.xml
+++ b/cloudslang-compiler/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cloudslang-content-maven-compiler/pom.xml
+++ b/cloudslang-content-maven-compiler/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cloudslang-content-verifier/pom.xml
+++ b/cloudslang-content-verifier/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cloudslang-content-verifier</artifactId>

--- a/cloudslang-content-verifier/pom.xml
+++ b/cloudslang-content-verifier/pom.xml
@@ -199,7 +199,6 @@
                             <id>cslang-builder</id>
                         </program>
                     </programs>
-                    <extraJvmArguments>-Dpython.path=@BASEDIR@/python-lib</extraJvmArguments>
                 </configuration>
             </plugin>
             <plugin>

--- a/cloudslang-content-verifier/src/main/resources/configuration/cslang.properties
+++ b/cloudslang-content-verifier/src/main/resources/configuration/cslang.properties
@@ -9,3 +9,5 @@ cloudslang.maven.repo.local=${app.home}/maven/repo
 cloudslang.maven.repo.remote.url=http://repo1.maven.org/maven2
 cloudslang.maven.plugins.remote.url=http://repo1.maven.org/maven2
 cloudslang.test.case.report.location=${app.home}/report
+use.jython.expressions=true
+#python.path=provide the python 3.8.7 path here

--- a/cloudslang-enforcer/pom.xml
+++ b/cloudslang-enforcer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cloudslang-entities/pom.xml
+++ b/cloudslang-entities/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/cloudslang-runtime/pom.xml
+++ b/cloudslang-runtime/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cloudslang-spi/pom.xml
+++ b/cloudslang-spi/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cloudslang-tests/pom.xml
+++ b/cloudslang-tests/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>cloudslang</artifactId>
         <groupId>io.cloudslang.lang</groupId>
-        <version>1.0.261-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!--Project dependencies-->
         <spring.version>5.3.4</spring.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <score.version>0.3.235</score.version>
+        <score.version>0.3.237</score.version>
         <h2.version>1.4.199</h2.version>
         <!--Project properties-->
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     -->
     <groupId>io.cloudslang.lang</groupId>
     <artifactId>cloudslang</artifactId>
-    <version>1.0.261-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
-Updated the cloud-slang version to 2.0.0-SNAPSHOT
-Added a flag to switch between external python and jython in CLI and builder.
