### PR TITLE
1394815 | can't  dynamically populate a variable from defined system …

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptEvaluator.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/scripts/ScriptEvaluator.java
@@ -94,6 +94,10 @@ public class ScriptEvaluator extends ScriptProcessor {
                                                      Set<ScriptFunction> functionDependencies) {
         Map<String, Serializable> pythonContext = createExternalPythonContext(context);
         boolean systemPropertiesDefined = functionDependencies.contains(ScriptFunction.GET_SYSTEM_PROPERTY);
+        if (expr.indexOf('$') != -1) {
+            systemPropertiesDefined = true;
+            functionDependencies.add(ScriptFunction.GET_SYSTEM_PROPERTY);
+        }
         if (systemPropertiesDefined) {
             pythonContext.put(SYSTEM_PROPERTIES_MAP,
                     (Serializable) prepareSystemPropertiesForExternalPython(systemProperties));


### PR DESCRIPTION
CPE Incident : 1394815 | can't  dynamically populate a variable from defined system property based on user input.