### PR TITLE
fix flaky tests

### DIFF
--- a/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/SeqStepsTransformer.java
+++ b/cloudslang-compiler/src/main/java/io/cloudslang/lang/compiler/modeller/transformers/SeqStepsTransformer.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang.Validate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -184,8 +185,8 @@ public class SeqStepsTransformer extends AbstractInOutForTransformer
         Validate.notNull(mandatoryKeySet);
         Validate.notNull(optionalKeySet);
 
-        Set<String> missingKeys = new HashSet<>();
-        Set<String> emptyValuesKeys = new HashSet<>();
+        Set<String> missingKeys = new TreeSet<>();
+        Set<String> emptyValuesKeys = new TreeSet<>();
         for (String reqKey : mandatoryKeySet) {
             String reqValue = tMap.get(reqKey);
             if (reqValue == null) {

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/SeqStepsTransformerTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/modeller/transformers/SeqStepsTransformerTest.java
@@ -78,7 +78,7 @@ public class SeqStepsTransformerTest extends TransformersTestParent {
 
         assertThat(transform.getErrors(), hasSize(1));
         assertEquals(transform.getErrors().get(0).getMessage(),
-                "Sequential operation step has the following missing tags: [object_path, action, id]");
+                "Sequential operation step has the following missing tags: [action, id, object_path]");
         assertEquals(expectedSteps, transform.getTransformedData());
     }
 
@@ -90,7 +90,7 @@ public class SeqStepsTransformerTest extends TransformersTestParent {
 
         assertThat(transform.getErrors(), hasSize(1));
         assertEquals(transform.getErrors().get(0).getMessage(),
-                "Sequential operation step has the following empty tags: [object_path, action, id]");
+                "Sequential operation step has the following empty tags: [action, id, object_path]");
         assertEquals(expectedSteps, transform.getTransformedData());
     }
 


### PR DESCRIPTION
## What's the purpose of this PR

Fix test `testTransformStepWithMissingReqKeys` and `testTransformStepWithEmptyReqKeys`

## Which issue(s) this PR fixes:

Fixes the issue that causes flaky tests. The current test may lead to inconsistent ordering of the ArrayList and thus cause the failure of the tests since the iterator of HashSet is inconsistent. To fix this issue, I utilized TreeSet to make sure the ordering would be consistent when we use the `toString` method.

## Brief changelog

Modified `testTransformStepWithMissingReqKeys` and `testTransformStepWithEmptyReqKeys`
Added `TreeSet` to `SeqStepsTransformer.java`
