### PR TITLE
fix flaky test

### DIFF
--- a/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/utils/MetadataHelperTest.java
+++ b/cloudslang-cli/src/test/java/io/cloudslang/lang/cli/utils/MetadataHelperTest.java
@@ -40,10 +40,10 @@ import static org.mockito.Mockito.mock;
 @ContextConfiguration(classes = {MetadataHelperTest.Config.class})
 public class MetadataHelperTest {
 
-    private static final String DESCRIPTION_AND_PREREQUISITES = "description: " + System.lineSeparator() +
+    private static final String DESCRIPTION = "description: " + System.lineSeparator() +
             "  Parses the given JSON input to retrieve the" + System.lineSeparator() +
-            "  corresponding value addressed by the json_path input." + System.lineSeparator() +
-            "prerequisites: jenkinsapi Python module";
+            "  corresponding value addressed by the json_path input.";
+    private static final String PREREQUISITES = "prerequisites: jenkinsapi Python module";
     private static final String JSON_INPUT_VALUE =
             "json_input: JSON data input - Example: '{\"k1\": {\"k2\": [\"v1\", \"v2\"]}}'";
     private static final String PREREQUISITES_MISSING = "description: " + System.lineSeparator() +
@@ -74,7 +74,8 @@ public class MetadataHelperTest {
         String metadataToPrint = metadataHelper.extractMetadata(new File(flowFilePath));
         Assert.assertNotNull(metadataToPrint);
         Assert.assertFalse(metadataToPrint.contains("io.cloudslang.lang.compiler.modeller.model.Metadata"));
-        Assert.assertTrue(metadataToPrint.contains(DESCRIPTION_AND_PREREQUISITES));
+        Assert.assertTrue(metadataToPrint.contains(DESCRIPTION));
+        Assert.assertTrue(metadataToPrint.contains(PREREQUISITES));
         Assert.assertTrue(metadataToPrint.contains(SOME_OTHER_RESULT));
         Assert.assertFalse(metadataToPrint.contains(SOME_OTHER_RESULT + ":"));
     }

--- a/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/MetadataExtractorTest.java
+++ b/cloudslang-compiler/src/test/java/io/cloudslang/lang/compiler/MetadataExtractorTest.java
@@ -30,10 +30,10 @@ public class MetadataExtractorTest {
 
     private static final String NEWLINE = System.lineSeparator();
 
-    private static final String DESCRIPTION_AND_PREREQUISITES = "description: " + NEWLINE +
+    private static final String DESCRIPTION = "description: " + NEWLINE +
             "  Parses the given JSON input to retrieve the" + NEWLINE +
-            "  corresponding value addressed by the json_path input." + NEWLINE +
-            "prerequisites: jenkinsapi Python module";
+            "  corresponding value addressed by the json_path input.";
+    private static final String PREREQUISITES = "prerequisites: jenkinsapi Python module";
     private static final String SOME_OTHER_RESULT = "SOME_OTHER_RESULT";
 
     @Autowired
@@ -70,7 +70,8 @@ public class MetadataExtractorTest {
         String metadataToPrint = metadata.prettyPrint();
         Assert.assertNotNull(metadataToPrint);
         Assert.assertFalse(metadataToPrint.contains("io.cloudslang.lang.compiler.modeller.model.Metadata"));
-        Assert.assertTrue(metadataToPrint.contains(DESCRIPTION_AND_PREREQUISITES));
+        Assert.assertTrue(metadataToPrint.contains(DESCRIPTION));
+        Assert.assertTrue(metadataToPrint.contains(PREREQUISITES));
         Assert.assertTrue(metadataToPrint.contains(SOME_OTHER_RESULT));
         Assert.assertFalse(metadataToPrint.contains(SOME_OTHER_RESULT + ":"));
     }


### PR DESCRIPTION
## What's the purpose of this PR

Fix test `testMetadataPrettyPrint` and `testPrettyPrint `

## Which issue(s) this PR fixes:

Fixes the issue that causes flaky tests. The current test doesn't guarantee the ordering of `metadataToPrint` due to the inconsistent ordering of `getDeclaredFields` method, and the test would fail in some circumstances. To fix this test, I separate `DESCRIPTION_AND_PREREQUISITES` to `DESCRIPTION ` and `PREREQUISITES `, so we don't need to worry about the ordering.

## Brief changelog

Separated `DESCRIPTION_AND_PREREQUISITES` to `DESCRIPTION ` and `PREREQUISITES `
