### PR TITLE
Compute the value as new one only if they are different

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -128,12 +128,13 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                         Value inputValue = userInputs.get(inputName);
                         Input inputToUpdate = executableInputsMap.get(inputName);
                         if (inputToUpdate != null) {
-                            Input updatedInput = new Input.InputBuilder(inputToUpdate, inputValue)
-                                    .build();
-                            mutableInputList.set(mutableInputList.indexOf(inputToUpdate), updatedInput);
                             // In case values are the same, do not compute the value again to avoid seeing it as a new const
                             if (inputToUpdate.getValue() != null && inputToUpdate.getValue().equals(inputValue)) {
                                 callArguments.remove(inputName);
+                            } else {
+                                Input updatedInput = new Input.InputBuilder(inputToUpdate, inputValue)
+                                        .build();
+                                mutableInputList.set(mutableInputList.indexOf(inputToUpdate), updatedInput);
                             }
                         } else {
                             Input toAddInput = new Input.InputBuilder(inputName, inputValue).build();

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -131,6 +131,10 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                             Input updatedInput = new Input.InputBuilder(inputToUpdate, inputValue)
                                     .build();
                             mutableInputList.set(mutableInputList.indexOf(inputToUpdate), updatedInput);
+                            // In case values are the same, do not compute the value again to avoid seeing it as a new const
+                            if (inputToUpdate.getValue() != null && inputToUpdate.getValue().equals(inputValue)) {
+                                callArguments.remove(inputName);
+                            }
                         } else {
                             Input toAddInput = new Input.InputBuilder(inputName, inputValue).build();
                             mutableInputList.add(toAddInput);
@@ -153,7 +157,7 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                 Map<String, Value> debuggerInputs =
                         (Map<String, Value>) systemContext.remove(DEBUGGER_EXECUTABLE_INPUTS);
                 List<Input> newInputs = debuggerInputs.entrySet().stream().map(entry ->
-                        new Input.InputBuilder(entry.getKey(), entry.getValue()).withRequired(false).build())
+                                new Input.InputBuilder(entry.getKey(), entry.getValue()).withRequired(false).build())
                         .collect(toList());
                 List<Input> updatedExecutableInputs = new ArrayList<>(newExecutableInputs.size() +
                         newInputs.size());


### PR DESCRIPTION
Before some API changes, for running an execution only the input's values that were changed were send in the request. Now all the input's values are sent and they are seen as different intentional values. 
The fix is to remove the unchanged values from the callArguments(so that the new value is not treated as a different value even if it's the same)