### PR TITLE
CloudSlang Prompts should no longer pop-up to end-users for inputs with value

### DIFF
--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -57,7 +57,8 @@ public class InputsBinding extends AbstractBinding {
                                          Set<SystemProperty> systemProperties,
                                          List<Input> missingInputs,
                                          boolean useEmptyValuesForPrompts,
-                                         Map<String, Prompt> prompts) {
+                                         Map<String, Prompt> prompts,
+                                         Boolean isCslangPromptEnabled) {
         Map<String, Value> resultContext = new LinkedHashMap<>();
 
         // we do not want to change original context map
@@ -70,7 +71,7 @@ public class InputsBinding extends AbstractBinding {
             input = overridePromptSettingIfExists(prompts, input);
 
             bindInput(input, srcContext, actualPromptContext, resultContext,
-                    systemProperties, missingInputs, useEmptyValuesForPrompts);
+                    systemProperties, missingInputs, useEmptyValuesForPrompts, isCslangPromptEnabled);
         }
 
         return resultContext;
@@ -79,7 +80,7 @@ public class InputsBinding extends AbstractBinding {
     private void bindInput(Input input, Map<String, ? extends Value> context,
                            Map<String, Value> promptContext, Map<String, Value> targetContext,
                            Set<SystemProperty> systemProperties, List<Input> missingInputs,
-                           boolean useEmptyValuesForPrompts) {
+                           boolean useEmptyValuesForPrompts, Boolean isCslangPromptEnabled) {
         Value value;
 
         String inputName = input.getName();
@@ -104,15 +105,32 @@ public class InputsBinding extends AbstractBinding {
             }
 
             if (input.hasPrompt()) {
-                if (useEmptyValuesForPrompts) {
+                if (!isCslangPromptEnabled) {
                     if (isNull(value)) {
-                        value = createEmptyValue(input);
+                        if (useEmptyValuesForPrompts) {
+                            value = createEmptyValue(input);
+                        }
+                        else {
+                            resolvePromptExpressions(input, context, targetContext, systemProperties);
+                            missingInputs.add(createMissingInput(input, value));
+                            return;
+                        }
                     }
-                } else if (isNull(promptValue)) {
-                    resolvePromptExpressions(input, context, targetContext, systemProperties);
-
-                    missingInputs.add(createMissingInput(input, value));
-                    return;
+                    else if (isEmpty(value)) {
+                        missingInputs.add(input);
+                        return;
+                    }
+                }
+                else {
+                    if (useEmptyValuesForPrompts) {
+                        if (isNull(value)) {
+                            value = createEmptyValue(input);
+                        }
+                    } else if (isNull(promptValue)) {
+                        resolvePromptExpressions(input, context, targetContext, systemProperties);
+                        missingInputs.add(createMissingInput(input, value));
+                        return;
+                    }
                 }
             } else if (input.isRequired() && isEmpty(value)) {
                 missingInputs.add(input);

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -106,22 +106,16 @@ public class InputsBinding extends AbstractBinding {
 
             if (input.hasPrompt()) {
                 if (!isCslangPromptEnabled) {
-                    if (isNull(value)) {
+                    if (isNull(value) || isEmpty(value)) {
                         if (useEmptyValuesForPrompts) {
                             value = createEmptyValue(input);
-                        }
-                        else {
+                        } else {
                             resolvePromptExpressions(input, context, targetContext, systemProperties);
                             missingInputs.add(createMissingInput(input, value));
                             return;
                         }
                     }
-                    else if (isEmpty(value)) {
-                        missingInputs.add(input);
-                        return;
-                    }
-                }
-                else {
+                } else {
                     if (useEmptyValuesForPrompts) {
                         if (isNull(value)) {
                             value = createEmptyValue(input);

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -58,7 +58,7 @@ public class InputsBinding extends AbstractBinding {
                                          List<Input> missingInputs,
                                          boolean useEmptyValuesForPrompts,
                                          Map<String, Prompt> prompts,
-                                         Boolean isCslangPromptEnabled) {
+                                         boolean isCslangPromptEnabled) {
         Map<String, Value> resultContext = new LinkedHashMap<>();
 
         // we do not want to change original context map
@@ -80,7 +80,7 @@ public class InputsBinding extends AbstractBinding {
     private void bindInput(Input input, Map<String, ? extends Value> context,
                            Map<String, Value> promptContext, Map<String, Value> targetContext,
                            Set<SystemProperty> systemProperties, List<Input> missingInputs,
-                           boolean useEmptyValuesForPrompts, Boolean isCslangPromptEnabled) {
+                           boolean useEmptyValuesForPrompts, boolean isCslangPromptEnabled) {
         Value value;
 
         String inputName = input.getName();

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/bindings/InputsBinding.java
@@ -109,7 +109,7 @@ public class InputsBinding extends AbstractBinding {
                     if (isNull(value) || isEmpty(value)) {
                         if (useEmptyValuesForPrompts) {
                             value = createEmptyValue(input);
-                        } else {
+                        } else if (isNull(promptValue)) {
                             resolvePromptExpressions(input, context, targetContext, systemProperties);
                             missingInputs.add(createMissingInput(input, value));
                             return;

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -185,7 +185,7 @@ public class ExecutableExecutionData extends AbstractExecutionData {
             Map<String, Value> magicVariables = magicVariableHelper.getGlobalContext(executionRuntimeServices);
             List<Input> missingInputs = new ArrayList<>();
             ReadOnlyContextAccessor context = new ReadOnlyContextAccessor(callArguments, magicVariables);
-            Boolean  isCslangPromptEnabled = executionRuntimeServices.getCslangPromptsEnabledFlag();
+            boolean isCslangPromptEnabled = executionRuntimeServices.getCslangPromptsEnabledFlag();
             Map<String, Value> boundInputValues = inputsBinding.bindInputs(
                     newExecutableInputs,
                     context.getMergedContexts(),

--- a/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
+++ b/cloudslang-runtime/src/main/java/io/cloudslang/lang/runtime/steps/ExecutableExecutionData.java
@@ -185,6 +185,7 @@ public class ExecutableExecutionData extends AbstractExecutionData {
             Map<String, Value> magicVariables = magicVariableHelper.getGlobalContext(executionRuntimeServices);
             List<Input> missingInputs = new ArrayList<>();
             ReadOnlyContextAccessor context = new ReadOnlyContextAccessor(callArguments, magicVariables);
+            Boolean  isCslangPromptEnabled = executionRuntimeServices.getCslangPromptsEnabledFlag();
             Map<String, Value> boundInputValues = inputsBinding.bindInputs(
                     newExecutableInputs,
                     context.getMergedContexts(),
@@ -192,7 +193,8 @@ public class ExecutableExecutionData extends AbstractExecutionData {
                     runEnv.getSystemProperties(),
                     missingInputs,
                     isTrue(useEmptyValuesForPrompts),
-                    promptArguments);
+                    promptArguments,
+                    isCslangPromptEnabled);
 
             boolean continueToNext = true;
             if (systemContext.containsKey(ScoreLangConstants.USER_INTERRUPT)) {

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/InputsBindingTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/bindings/InputsBindingTest.java
@@ -515,7 +515,7 @@ public class InputsBindingTest {
                                           Map<String, Value> promptArgs,
                                           Set<SystemProperty> systemProperties, List<Input> missingInputs) {
         return inputsBinding.bindInputs(inputs, context, promptArgs, systemProperties, missingInputs,
-                false, new HashMap<>());
+                false, new HashMap<>(), true);
     }
 
     private Map<String, Value> bindInputs(List<Input> inputs, Map<String, Value> context) {

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
@@ -138,9 +138,11 @@ public class ExecutableStepsTest {
         Map<String, Value> resultMap = new HashMap<>();
         resultMap.put("input1", ValueFactory.create(5));
 
-        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anyMap(), anySet(), anyList(), anyBoolean(), anyMap()))
+        when(inputsBinding
+                .bindInputs(eq(inputs), anyMap(), anyMap(), anySet(), anyList(), anyBoolean(), anyMap(), true))
                 .thenReturn(resultMap);
-        executableSteps.startExecutable(inputs, runEnv, new HashMap<String, Value>(),
+        executableSteps
+                .startExecutable(inputs, runEnv, new HashMap<String, Value>(),
                 new ExecutionRuntimeServices(), "", 2L, ExecutableType.FLOW, new SystemContext(), false);
 
         Map<String, Value> opVars = runEnv.getStack().popContext().getImmutableViewOfVariables();
@@ -168,7 +170,8 @@ public class ExecutableStepsTest {
         resultMap.put("input1", ValueFactory.create(inputs.get(0).getValue()));
         resultMap.put("input2", ValueFactory.create(inputs.get(1).getValue()));
 
-        when(inputsBinding.bindInputs(eq(inputs), anyMap(), anyMap(), anySet(), anyList(), anyBoolean(), anyMap()))
+        when(inputsBinding
+                .bindInputs(eq(inputs), anyMap(), anyMap(), anySet(), anyList(), anyBoolean(), anyMap(), true))
                 .thenReturn(resultMap);
         executableSteps.startExecutable(inputs, runEnv, new HashMap<String, Value>(),
                 runtimeServices, "dockerizeStep", 2L, ExecutableType.FLOW, new SystemContext(), false);

--- a/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
+++ b/cloudslang-runtime/src/test/java/io/cloudslang/lang/runtime/steps/ExecutableStepsTest.java
@@ -139,7 +139,7 @@ public class ExecutableStepsTest {
         resultMap.put("input1", ValueFactory.create(5));
 
         when(inputsBinding
-                .bindInputs(eq(inputs), anyMap(), anyMap(), anySet(), anyList(), anyBoolean(), anyMap(), true))
+                .bindInputs(eq(inputs), anyMap(), anyMap(), anySet(), anyList(), anyBoolean(), anyMap(), anyBoolean()))
                 .thenReturn(resultMap);
         executableSteps
                 .startExecutable(inputs, runEnv, new HashMap<String, Value>(),
@@ -171,7 +171,7 @@ public class ExecutableStepsTest {
         resultMap.put("input2", ValueFactory.create(inputs.get(1).getValue()));
 
         when(inputsBinding
-                .bindInputs(eq(inputs), anyMap(), anyMap(), anySet(), anyList(), anyBoolean(), anyMap(), true))
+                .bindInputs(eq(inputs), anyMap(), anyMap(), anySet(), anyList(), anyBoolean(), anyMap(), anyBoolean()))
                 .thenReturn(resultMap);
         executableSteps.startExecutable(inputs, runEnv, new HashMap<String, Value>(),
                 runtimeServices, "dockerizeStep", 2L, ExecutableType.FLOW, new SystemContext(), false);


### PR DESCRIPTION
- Default behaviour of cslang flows will prompt the user despite the values of inputs are available at runtime for all the inputs marked as prompt user. 
- Enhanced the behaviour to support for not prompting if the input value is available at runtime. 
- The behaviour can be changed using a boolean flag (with default being the older behaviour).
- The engine will still prompt for those inputs whose value is empty/null at runtime and is marked as prompt user.